### PR TITLE
Fix GitHub Pages workflow Node version for cubing dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install


### PR DESCRIPTION
## Summary
- update the GitHub Pages deployment workflow to install Node.js 22 so dependencies requiring the latest engine can be installed

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68f1d94b0458832d956965bd239e5598