### PR TITLE
Fix mirroring behavior in CaseCard

### DIFF
--- a/src/lib/components/CaseCard.svelte
+++ b/src/lib/components/CaseCard.svelte
@@ -6,7 +6,8 @@
 	import getRotationAlg from '$lib/rotation';
 	import getStickeringString from '$lib/stickering';
 	import type { CaseId, GroupId } from '$lib/types/group';
-	import { Button } from 'flowbite-svelte';
+        import { Button } from 'flowbite-svelte';
+        import { mirrorAlg } from '$lib/mirrorAlg';
 
 	let {
 		groupId,
@@ -19,12 +20,16 @@
 	const staticData = casesStatic[groupId][caseId];
 	const caseState = casesState[groupId][caseId];
 
-	const selectedAlgorithm = $derived(
-		caseState.customAlgorithm.left.trim() ||
-			staticData.algPool[caseState.algorithmSelection.right] ||
-			staticData.algPool[0] ||
-			''
-	);
+        const selectedAlgorithm = $derived(
+                caseState.customAlgorithm.left.trim() ||
+                        staticData.algPool[caseState.algorithmSelection.right] ||
+                        staticData.algPool[0] ||
+                        ''
+        );
+
+        const displayedAlgorithm = $derived(
+                caseState.mirrored ? mirrorAlg(selectedAlgorithm) : selectedAlgorithm
+        );
 
 	const selectedScramble = $derived(
 		staticData.scramblePool[caseState.algorithmSelection.right] || staticData.scramblePool[0] || ''
@@ -38,17 +43,19 @@
 			caseState.mirrored
 		)
 	);
-	const setupRotation = $derived(getRotationAlg(globalState.crossColor, globalState.frontColor));
+        const setupRotation = $derived(getRotationAlg(globalState.crossColor, globalState.frontColor));
+        const cameraLongitude = $derived(caseState.mirrored ? -25 : 25);
 </script>
 
 <div class="flex items-center rounded-2xl border-3">
-	<TwistyPlayer
-		alg={selectedAlgorithm}
-		{setupRotation}
-		setupAlg={selectedScramble}
-		{stickeringString}
-	/>
-	<span> {selectedAlgorithm} </span>
+        <TwistyPlayer
+                alg={displayedAlgorithm}
+                {setupRotation}
+                setupAlg={selectedScramble}
+                {stickeringString}
+                {cameraLongitude}
+        />
+        <span> {displayedAlgorithm} </span>
 	<Button
 		onclick={() => {
 			caseState.mirrored = !caseState.mirrored;


### PR DESCRIPTION
## Summary
- mirror displayed algorithms when a case is toggled to mirrored
- flip the twisty player's camera longitude when mirrored so the view matches

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f1ffabbf08832d929c4c331178b067