### PR TITLE
Pull Request: New "Scramble Yourself" Train Mode & UI Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ vite.config.ts.timestamp-*
 
 # Screenshots
 screenshots
+
+# Video Script
+docs/video-script.md

--- a/docs/implementation_plan_scramble_yourself_mode.md
+++ b/docs/implementation_plan_scramble_yourself_mode.md
@@ -1,0 +1,184 @@
+# New Training Mode: "Scramble Yourself"
+
+This mode combines Standard Practice (classic) with smart cube integration, requiring the user to physically scramble their cube while the virtual cube tracks and validates their moves. After scrambling, a configurable countdown starts, then the user solves the case while being timed with recognition/execution splits.
+
+## Step-by-Step Implementation
+
+1. Start by adding the option to [SessionSettingsModal.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/Session/SessionSettingsModal.svelte) without including it into convex. Make this new setting show the new train component which is empty for now.
+2. After checking if it works, add the scramble to the train component and the twisty player. Make sure that the twisty player shows the unscrambled cube before the user applies a scramble. Right now [TwistyPlayer.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TwistyPlayer.svelte) automatically adds a scramble according to its groupid and caseid.
+3. After checking if the scrambling works correctly, implement the countdown.
+4. After checking that, add the algorithm hint. It would be best if we could use [HintButtonSmart.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/HintButtonSmart.svelte) for this and just adapt it a bit if necessary.
+5. After that works, add the [DrillTimer.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/DrillTimer.svelte). Decide if you want to reuse this component or create a copy.
+6. After that works, add the [Details.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/Details.svelte), [RecapProgress.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/RecapProgress.svelte) and [TrainStateSelect.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/TrainStateSelect.svelte).
+7. After that works, implement it into convex.
+
+## Resolved Design Decisions
+
+- **Statistics trainMode:** New 4th value `smartScramble` for separate tracking
+- **Countdown duration:** Configurable via Range slider (like Drill Flow), with progressbar
+- **Virtual cube during scramble:** Optional — new checkbox "Show cube while scrambling"
+- **Wrong scramble moves:** Undo guidance (same as HintButtonSmart)
+- **Transition delay after solve:** Fixed 500ms with green checkmark (TrainClassicSmart style)
+- **Checkbox visibility:** Always visible inside Standard Practice card, only effective when `trainMode === 'classic'`
+
+## Proposed Changes
+
+### Statistics Types & Compression
+
+#### [MODIFY] [statisticsState.ts](file:///d:/WebDevelopment/F2LTrainer/src/lib/statisticsState.ts)
+- Add `smartScramble` to TrainMode union: `'classic' | 'smart' | 'drill' | 'smartScramble'`
+- Add `ss` to CompressedSolve.m union: `'c' | 's' | 'd' | 'ss'`
+
+#### [MODIFY] [statisticsState.svelte.ts](file:///d:/WebDevelopment/F2LTrainer/src/lib/statisticsState.svelte.ts)
+- Add `smartScramble: 'ss'` to `MODE_MAP`
+- Add `ss: 'smartScramble'` to `REVERSE_MODE_MAP`
+
+---
+
+### Session Types & Settings
+
+#### [MODIFY] [session.ts](file:///d:/WebDevelopment/F2LTrainer/src/lib/session.ts)
+Add to `SessionSettings` interface:
+```typescript
+scrambleYourself: boolean; // Enable "Scramble Yourself" mode
+scrambleCountdownDuration: number; // Seconds before solving starts (like drillTimeBetweenCases)
+scrambleShowCube: boolean; // Show virtual cube while scrambling
+```
+
+#### [MODIFY] [sessionState.svelte.ts](file:///d:/WebDevelopment/F2LTrainer/src/lib/sessionState.svelte.ts)
+Add to `DEFAULT_SETTINGS`:
+```typescript
+scrambleYourself: false,
+scrambleCountdownDuration: 1.0,
+scrambleShowCube: true,
+```
+
+---
+
+### Session Settings UI
+
+#### [MODIFY] [SessionSettingsModal.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/Session/SessionSettingsModal.svelte)
+Inside the Standard Practice radio card:
+- Add a Checkbox for "Scramble yourself" — always visible regardless of which trainMode is selected, but only takes effect when `trainMode === 'classic'`
+- Brief description: "Scramble your smart cube yourself. Requires Smart Cube."
+
+Below the Training Activity section (conditionally shown when `scrambleYourself === true` AND `trainMode === 'classic'`):
+- Add a "Scramble Flow" card (similar to the existing "Drill Flow" card)
+- Range slider for `scrambleCountdownDuration` (0–5s, step 0.25s)
+  - Label: "Countdown Duration" with current value display (e.g., "1.0s")
+  - Description: "Time between completing scramble and seeing the case."
+- Checkbox for `scrambleShowCube`: "Show Cube While Scrambling"
+  - Description: "Display the virtual cube updating as you scramble. When off, the cube is hidden until you start solving."
+
+---
+
+### Training View Routing
+
+#### [MODIFY] [TrainView.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/TrainView.svelte)
+Update the routing logic:
+```svelte
+{#if activeSettings.trainMode === 'drill'}
+  <TrainDrill bind:isRunning={isDrillRunning} />
+{:else if bluetoothState.isConnected && activeSettings.scrambleYourself}
+  <!-- Scramble Yourself mode (requires classic + connected smart cube) -->
+  <TrainClassicScramble />
+{:else if bluetoothState.isConnected}
+  <!-- Auto smart cube training when connected -->
+  <TrainClassicSmart />
+{:else}
+  <!-- Default Classic Mode -->
+  <TrainClassic />
+{/if}
+```
+
+---
+
+### New Training Component
+
+#### [NEW] [TrainClassicScramble.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/TrainClassicScramble.svelte)
+This is the main new component. It combines elements from `TrainClassicSmart` and `TrainDrill`.
+
+**State Machine Phases:**
+`scrambling` → `countdown` → `solving` → `executing` → `transitioning` → (next case → `scrambling`)
+
+**Phase details:**
+
+- **scrambling:**
+  - The scramble text is shown at the top.
+  - The virtual cube starts unsolved. If `scrambleShowCube` is true, the `TwistyPlayer` is visible; otherwise, it's hidden.
+  - Each smart cube move is applied to the virtual `TwistyPlayer` via `addMove()`.
+  - Validated against the scramble sequence using `HintButtonSmart`'s validation logic.
+  - Wrong moves trigger undo guidance (amber undo chips).
+  - When all scramble moves are matched → transition to `countdown`.
+  - `HintButtonSmart` displays the scramble as the algorithm to follow, with completed/current/future move chips.
+- **countdown:**
+  - The virtual cube is hidden.
+  - A progressbar countdown is shown (configurable duration via `scrambleCountdownDuration`).
+  - Uses the same radial progress animation style as `TrainDrill`'s transition overlay.
+  - "Hold Green Front, White Up" badge shown.
+  - Smart cube moves are ignored during countdown.
+- **solving:**
+  - The virtual cube is shown (scramble was already applied move-by-move).
+  - `DrillTimer` starts the recognition phase.
+  - Smart cube moves are tracked; first non-U move transitions to `executing`.
+- **executing:**
+  - `DrillTimer` switches to execution phase.
+  - Move validation against the algorithm is active (like `TrainClassicSmart`).
+  - `HintButtonSmart` shows the solving algorithm with progress tracking.
+  - `onF2LSolved` detection triggers completion.
+- **transitioning:**
+  - Green checkmark overlay with pulse animation (from `TrainClassicSmart`).
+  - Solve time (recognition + execution) recorded with `trainMode: 'smartScramble'`.
+  - After 500ms delay, advance to next case and reset to `scrambling`.
+
+**Key implementation details:**
+- During the scramble phase, the `TwistyPlayer` uses an empty scramble so the cube appears solved. The scramble moves get applied via `addMove()` as the user performs them on the physical cube.
+- The scramble sequence is parsed from the scramble string (using `getCaseScramble` + `concatinateAuf`).
+- During the solve phase, the cube already has the scramble applied. The user's solving moves are tracked via `addMove()`.
+- `HintButtonSmart` is reused in both phases:
+  - Scrambling: `alg` prop = scramble moves, `currentMoveIndex` tracks scramble progress.
+  - Solving: `alg` prop = solving algorithm (with AUF), `currentMoveIndex` tracks algorithm progress.
+- `DrillTimer` handles recognition/execution timing (only during solve phase).
+- Bluetooth connection pattern identical to `TrainClassicSmart` (subscriber pattern with priority).
+- Rotation warning (from `TrainClassicSmart`) shown between cases if cumulative rotation is non-empty.
+
+**Components reused:**
+- `TwistyPlayer`
+- `HintButtonSmart`
+- `DrillTimer`
+- `RecapProgress`
+- `Details`
+- `TrainStateSelect`
+- `BluetoothModal`
+- `EditAlg`
+- `Settings`
+
+---
+
+### Session Manager / Toolbar
+
+#### [MODIFY] [SessionToolbar.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/Session/SessionToolbar.svelte)
+- If the session has `scrambleYourself: true` and `trainMode: 'classic'`, optionally show a visual indicator badge.
+
+#### [MODIFY] [SessionManagerModal.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/Session/SessionManagerModal.svelte)
+- Same optional visual indicator for sessions with `scrambleYourself` enabled.
+
+## Verification Plan
+
+### Automated Tests
+- Run `npm run check` to verify TypeScript compilation
+- Run `npm run build` to ensure no build errors
+
+### Manual Verification
+1. Create a new session, check "Scramble yourself" under Standard Practice
+2. Verify the "Scramble Flow" settings card appears with Range slider and "Show Cube" checkbox
+3. Connect a smart cube → verify `TrainClassicScramble` loads
+4. **Scramble phase:** Verify scramble text shown, moves applied to virtual cube, wrong moves show undo guidance, cube visibility respects `scrambleShowCube` setting
+5. **Countdown:** Verify progressbar countdown runs for configured duration after scramble complete
+6. **Solve phase:** Verify timer starts, recognition/execution split works, F2L detection triggers completion
+7. **Transition:** Verify checkmark overlay, auto-advance to next case back to scramble phase
+8. Verify `RecapProgress`, `Details`, `TrainStateSelect` all work
+9. Disconnect smart cube → verify it falls back to `TrainClassic`
+10. Uncheck "Scramble yourself" → verify normal `TrainClassicSmart` behavior when connected
+11. Check statistics are saved with `trainMode: 'smartScramble'`
+12. Verify "Scramble yourself" checkbox is visible even when Speed Drill is selected (but has no effect)

--- a/docs/implementation_plan_scramble_yourself_mode.md
+++ b/docs/implementation_plan_scramble_yourself_mode.md
@@ -26,10 +26,12 @@ This mode combines Standard Practice (classic) with smart cube integration, requ
 ### Statistics Types & Compression
 
 #### [MODIFY] [statisticsState.ts](file:///d:/WebDevelopment/F2LTrainer/src/lib/statisticsState.ts)
+
 - Add `smartScramble` to TrainMode union: `'classic' | 'smart' | 'drill' | 'smartScramble'`
 - Add `ss` to CompressedSolve.m union: `'c' | 's' | 'd' | 'ss'`
 
 #### [MODIFY] [statisticsState.svelte.ts](file:///d:/WebDevelopment/F2LTrainer/src/lib/statisticsState.svelte.ts)
+
 - Add `smartScramble: 'ss'` to `MODE_MAP`
 - Add `ss: 'smartScramble'` to `REVERSE_MODE_MAP`
 
@@ -38,7 +40,9 @@ This mode combines Standard Practice (classic) with smart cube integration, requ
 ### Session Types & Settings
 
 #### [MODIFY] [session.ts](file:///d:/WebDevelopment/F2LTrainer/src/lib/session.ts)
+
 Add to `SessionSettings` interface:
+
 ```typescript
 scrambleYourself: boolean; // Enable "Scramble Yourself" mode
 scrambleCountdownDuration: number; // Seconds before solving starts (like drillTimeBetweenCases)
@@ -46,7 +50,9 @@ scrambleShowCube: boolean; // Show virtual cube while scrambling
 ```
 
 #### [MODIFY] [sessionState.svelte.ts](file:///d:/WebDevelopment/F2LTrainer/src/lib/sessionState.svelte.ts)
+
 Add to `DEFAULT_SETTINGS`:
+
 ```typescript
 scrambleYourself: false,
 scrambleCountdownDuration: 1.0,
@@ -58,11 +64,14 @@ scrambleShowCube: true,
 ### Session Settings UI
 
 #### [MODIFY] [SessionSettingsModal.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/Session/SessionSettingsModal.svelte)
+
 Inside the Standard Practice radio card:
+
 - Add a Checkbox for "Scramble yourself" — always visible regardless of which trainMode is selected, but only takes effect when `trainMode === 'classic'`
 - Brief description: "Scramble your smart cube yourself. Requires Smart Cube."
 
 Below the Training Activity section (conditionally shown when `scrambleYourself === true` AND `trainMode === 'classic'`):
+
 - Add a "Scramble Flow" card (similar to the existing "Drill Flow" card)
 - Range slider for `scrambleCountdownDuration` (0–5s, step 0.25s)
   - Label: "Countdown Duration" with current value display (e.g., "1.0s")
@@ -75,19 +84,21 @@ Below the Training Activity section (conditionally shown when `scrambleYourself 
 ### Training View Routing
 
 #### [MODIFY] [TrainView.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/TrainView.svelte)
+
 Update the routing logic:
+
 ```svelte
 {#if activeSettings.trainMode === 'drill'}
-  <TrainDrill bind:isRunning={isDrillRunning} />
+	<TrainDrill bind:isRunning={isDrillRunning} />
 {:else if bluetoothState.isConnected && activeSettings.scrambleYourself}
-  <!-- Scramble Yourself mode (requires classic + connected smart cube) -->
-  <TrainClassicScramble />
+	<!-- Scramble Yourself mode (requires classic + connected smart cube) -->
+	<TrainClassicScramble />
 {:else if bluetoothState.isConnected}
-  <!-- Auto smart cube training when connected -->
-  <TrainClassicSmart />
+	<!-- Auto smart cube training when connected -->
+	<TrainClassicSmart />
 {:else}
-  <!-- Default Classic Mode -->
-  <TrainClassic />
+	<!-- Default Classic Mode -->
+	<TrainClassic />
 {/if}
 ```
 
@@ -96,6 +107,7 @@ Update the routing logic:
 ### New Training Component
 
 #### [NEW] [TrainClassicScramble.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/TrainView/TrainClassicScramble.svelte)
+
 This is the main new component. It combines elements from `TrainClassicSmart` and `TrainDrill`.
 
 **State Machine Phases:**
@@ -132,6 +144,7 @@ This is the main new component. It combines elements from `TrainClassicSmart` an
   - After 500ms delay, advance to next case and reset to `scrambling`.
 
 **Key implementation details:**
+
 - During the scramble phase, the `TwistyPlayer` uses an empty scramble so the cube appears solved. The scramble moves get applied via `addMove()` as the user performs them on the physical cube.
 - The scramble sequence is parsed from the scramble string (using `getCaseScramble` + `concatinateAuf`).
 - During the solve phase, the cube already has the scramble applied. The user's solving moves are tracked via `addMove()`.
@@ -143,6 +156,7 @@ This is the main new component. It combines elements from `TrainClassicSmart` an
 - Rotation warning (from `TrainClassicSmart`) shown between cases if cumulative rotation is non-empty.
 
 **Components reused:**
+
 - `TwistyPlayer`
 - `HintButtonSmart`
 - `DrillTimer`
@@ -158,18 +172,22 @@ This is the main new component. It combines elements from `TrainClassicSmart` an
 ### Session Manager / Toolbar
 
 #### [MODIFY] [SessionToolbar.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/Session/SessionToolbar.svelte)
+
 - If the session has `scrambleYourself: true` and `trainMode: 'classic'`, optionally show a visual indicator badge.
 
 #### [MODIFY] [SessionManagerModal.svelte](file:///d:/WebDevelopment/F2LTrainer/src/lib/components/Session/SessionManagerModal.svelte)
+
 - Same optional visual indicator for sessions with `scrambleYourself` enabled.
 
 ## Verification Plan
 
 ### Automated Tests
+
 - Run `npm run check` to verify TypeScript compilation
 - Run `npm run build` to ensure no build errors
 
 ### Manual Verification
+
 1. Create a new session, check "Scramble yourself" under Standard Practice
 2. Verify the "Scramble Flow" settings card appears with Range slider and "Show Cube" checkbox
 3. Connect a smart cube → verify `TrainClassicScramble` loads

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -20,18 +20,8 @@
 	});
 </script>
 
-<FlowbiteModal bind:open classes={mergedClasses} {...restProps}>
+<FlowbiteModal bind:open classes={mergedClasses} header={headerSnippet} footer={footerSnippet} {...restProps}>
 	{#if children}
 		{@render children()}
-	{/if}
-	{#if headerSnippet}
-		{#snippet header()}
-			{@render headerSnippet()}
-		{/snippet}
-	{/if}
-	{#if footerSnippet}
-		{#snippet footer()}
-			{@render footerSnippet()}
-		{/snippet}
 	{/if}
 </FlowbiteModal>

--- a/src/lib/components/Modals/CaseStatsModal.svelte
+++ b/src/lib/components/Modals/CaseStatsModal.svelte
@@ -75,10 +75,13 @@
 		}
 		const options = [];
 		if (types.has('classic')) options.push({ value: 'classic', name: 'Standard Practice' });
-		if (types.has('smart')) options.push({ value: 'smart', name: 'Smart Practice' });
-		if (types.has('drill')) options.push({ value: 'drill', name: 'Drill' });
+		if (types.has('smart')) options.push({ value: 'smart', name: 'Standard Practice (Smart)' });
 		if (types.has('smartScramble'))
-			options.push({ value: 'smartScramble', name: 'Smart Practice (scramble yourself)' });
+			options.push({
+				value: 'smartScramble',
+				name: 'Standard Practice (Smart, Scramble Yourself)'
+			});
+		if (types.has('drill')) options.push({ value: 'drill', name: 'Speed Drill' });
 		return options;
 	});
 
@@ -438,7 +441,8 @@
 
 		<!-- Train Type Filter -->
 		{#if trainTypeOptions.length > 1}
-			<div class="flex justify-center">
+			<div class="flex items-center justify-center gap-2">
+				<span class="text-sm font-medium text-gray-600 dark:text-gray-400">Train Mode:</span>
 				<Select bind:value={trainTypeFilter} items={trainTypeOptions} placeholder="" class="w-80" />
 			</div>
 		{/if}

--- a/src/lib/components/Modals/CaseStatsModal.svelte
+++ b/src/lib/components/Modals/CaseStatsModal.svelte
@@ -541,7 +541,7 @@
 								>
 							{:else}
 								<Badge
-									color="light"
+									color="amber"
 									rounded
 									class="cursor-pointer !bg-transparent text-sm {hoveredIndex === realIndex ||
 									selectedIndex === realIndex

--- a/src/lib/components/Modals/CaseStatsModal.svelte
+++ b/src/lib/components/Modals/CaseStatsModal.svelte
@@ -78,7 +78,7 @@
 		if (types.has('smart')) options.push({ value: 'smart', name: 'Smart Practice' });
 		if (types.has('drill')) options.push({ value: 'drill', name: 'Drill' });
 		if (types.has('smartScramble'))
-			options.push({ value: 'smartScramble', name: 'Smart Practice (scramble yourself' });
+			options.push({ value: 'smartScramble', name: 'Smart Practice (scramble yourself)' });
 		return options;
 	});
 

--- a/src/lib/components/Modals/CaseStatsModal.svelte
+++ b/src/lib/components/Modals/CaseStatsModal.svelte
@@ -77,6 +77,8 @@
 		if (types.has('classic')) options.push({ value: 'classic', name: 'Standard Practice' });
 		if (types.has('smart')) options.push({ value: 'smart', name: 'Smart Practice' });
 		if (types.has('drill')) options.push({ value: 'drill', name: 'Drill' });
+		if (types.has('smartScramble'))
+			options.push({ value: 'smartScramble', name: 'Smart Practice (scramble yourself' });
 		return options;
 	});
 
@@ -102,7 +104,7 @@
 			.map((s) => {
 				let time = s.time;
 				if (trainTypeFilter === 'smart') time = s.executionTime;
-				if (trainTypeFilter === 'drill')
+				if (trainTypeFilter === 'drill' || trainTypeFilter === 'smartScramble')
 					time =
 						s.recognitionTime !== undefined && s.executionTime !== undefined
 							? s.recognitionTime + s.executionTime

--- a/src/lib/components/Modals/SessionStatsModal.svelte
+++ b/src/lib/components/Modals/SessionStatsModal.svelte
@@ -122,6 +122,8 @@
 		if (types.has('classic')) options.push({ value: 'classic', name: 'Standard Practice' });
 		if (types.has('smart')) options.push({ value: 'smart', name: 'Smart Practice' });
 		if (types.has('drill')) options.push({ value: 'drill', name: 'Drill' });
+		if (types.has('smartScramble'))
+			options.push({ value: 'smartScramble', name: 'Smart Practice (scramble yourself)' });
 		return options;
 	});
 
@@ -139,7 +141,7 @@
 			.map((s) => {
 				let time = s.time;
 				if (trainTypeFilter === 'smart') time = s.executionTime;
-				if (trainTypeFilter === 'drill')
+				if (trainTypeFilter === 'drill' || trainTypeFilter === 'smartScramble')
 					time =
 						s.recognitionTime !== undefined && s.executionTime !== undefined
 							? s.recognitionTime + s.executionTime
@@ -168,12 +170,12 @@
 	const meanTime = $derived(calculateMean(displaySolves));
 	// Drill specific means
 	const meanRec = $derived(
-		trainTypeFilter === 'drill'
+		trainTypeFilter === 'drill' || trainTypeFilter === 'smartScramble'
 			? calculateMean(displaySolves.map((s) => ({ ...s, time: s.recognitionTime }) as Solve))
 			: undefined
 	);
 	const meanExec = $derived(
-		trainTypeFilter === 'drill'
+		trainTypeFilter === 'drill' || trainTypeFilter === 'smartScramble'
 			? calculateMean(displaySolves.map((s) => ({ ...s, time: s.executionTime }) as Solve))
 			: undefined
 	);
@@ -373,7 +375,8 @@
 
 		<!-- Summary Stats Grid -->
 		<div
-			class="grid gap-3 text-center {trainTypeFilter === 'drill'
+			class="grid gap-3 text-center {trainTypeFilter === 'drill' ||
+			trainTypeFilter === 'smartScramble'
 				? 'grid-cols-3 sm:grid-cols-7'
 				: 'grid-cols-3 sm:grid-cols-5'}"
 		>
@@ -422,7 +425,7 @@
 			</div>
 
 			<!-- Drill Split Stats -->
-			{#if trainTypeFilter === 'drill'}
+			{#if trainTypeFilter === 'drill' || trainTypeFilter === 'smartScramble'}
 				<div class="stat-card">
 					<span class="text-secondary sm:text-base">Mean Rec</span>
 					<span class="font-mono text-lg leading-tight font-bold text-gray-900 dark:text-white"

--- a/src/lib/components/Modals/SessionStatsModal.svelte
+++ b/src/lib/components/Modals/SessionStatsModal.svelte
@@ -120,10 +120,13 @@
 		}
 		const options = [];
 		if (types.has('classic')) options.push({ value: 'classic', name: 'Standard Practice' });
-		if (types.has('smart')) options.push({ value: 'smart', name: 'Smart Practice' });
-		if (types.has('drill')) options.push({ value: 'drill', name: 'Drill' });
+		if (types.has('smart')) options.push({ value: 'smart', name: 'Standard Practice (Smart)' });
 		if (types.has('smartScramble'))
-			options.push({ value: 'smartScramble', name: 'Smart Practice (scramble yourself)' });
+			options.push({
+				value: 'smartScramble',
+				name: 'Standard Practice (Smart, Scramble Yourself)'
+			});
+		if (types.has('drill')) options.push({ value: 'drill', name: 'Speed Drill' });
 		return options;
 	});
 
@@ -368,8 +371,9 @@
 
 		<!-- Train Type Filter -->
 		{#if trainTypeOptions.length > 1}
-			<div class="flex justify-center">
-				<Select bind:value={trainTypeFilter} items={trainTypeOptions} placeholder="" class="w-64" />
+			<div class="flex items-center justify-center gap-2">
+				<span class="text-sm font-medium text-gray-600 dark:text-gray-400">Train Mode:</span>
+				<Select bind:value={trainTypeFilter} items={trainTypeOptions} placeholder="" class="w-80" />
 			</div>
 		{/if}
 

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -161,7 +161,7 @@
 						bind:value={session.name}
 						placeholder="Enter session name"
 						maxlength={60}
-						class="w-64 rounded-md border-b-2 border-primary-500 bg-gray-50 px-1 py-0.5 text-xl font-medium text-gray-900 focus:outline-none dark:bg-gray-700 dark:text-white"
+						class="w-64 rounded-md border-b-2 border-transparent bg-gray-50 px-1 py-0.5 text-xl font-medium text-gray-900 focus:border-primary-500 focus:outline-none dark:bg-gray-700 dark:text-white"
 					/>
 				{:else}
 					<h3 class="flex items-center gap-1.5 px-1 py-0.5 text-xl font-medium text-gray-900 dark:text-white">

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -26,6 +26,7 @@
 	import EdgeOrientationTooltipPreview from '$lib/components/Session/EdgeOrientationTooltipPreview.svelte';
 	import SessionIndividualCaseSelector from '$lib/components/Session/SessionIndividualCaseSelector.svelte';
 	import resolveStickerColors from '$lib/utils/resolveStickerColors';
+	import type { SessionSettingsTab } from '$lib/types/globalState';
 
 	let {
 		open = $bindable(),
@@ -100,6 +101,12 @@
 		globalState.eoOrientedColor !== DEFAULT_EO_ORIENTED_COLOR ||
 			globalState.eoUnorientedColor !== DEFAULT_EO_UNORIENTED_COLOR
 	);
+	// Track selected settings tab (local state synced to globalState)
+	let selectedSettingsTab: SessionSettingsTab = $state(globalState.sessionSettingsTab);
+
+	$effect(() => {
+		globalState.sessionSettingsTab = selectedSettingsTab;
+	});
 </script>
 
 {#if session && settings}
@@ -124,12 +131,13 @@
 			</div>
 
 			<Tabs
+				bind:selected={selectedSettingsTab}
 				tabStyle="underline"
 				classes={{
 					content: 'p-0 bg-gray-50 rounded-lg dark:bg-gray-800 mt-0'
 				}}
 			>
-				<TabItem open title="Selection">
+				<TabItem key="selection" title="Selection">
 					<div class="mt-4 flex flex-col gap-4">
 						<!-- Group Selection Card -->
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -209,7 +217,7 @@
 					</div>
 				</TabItem>
 
-				<TabItem title="Training">
+				<TabItem key="training" title="Training">
 					<div class="mt-4 flex flex-col gap-4">
 						<!-- Training Activity Section -->
 						<div class="flex flex-col gap-4">
@@ -558,7 +566,7 @@
 					</div>
 				</TabItem>
 
-				<TabItem title="Appearance">
+				<TabItem key="appearance" title="Appearance">
 					<div class="mt-4 flex flex-col gap-4">
 						<!-- Cube Appearance Section -->
 						<div class="flex flex-col gap-4">

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -28,7 +28,8 @@
 		RotateCcw,
 		ChevronDown,
 		ChevronRight,
-		Settings
+		Settings,
+		Pencil
 	} from '@lucide/svelte';
 	import TooltipButton from '$lib/components/Modals/TooltipButton.svelte';
 	import EdgeOrientationTooltipPreview from '$lib/components/Session/EdgeOrientationTooltipPreview.svelte';
@@ -122,28 +123,62 @@
 	$effect(() => {
 		globalState.sessionSettingsTab = selectedSettingsTab;
 	});
+
+	let isEditingName = $state(false);
+	let nameInputEl = $state<HTMLInputElement | null>(null);
+
+	function startEditingName() {
+		isEditingName = true;
+		tick().then(() => {
+			if (nameInputEl) {
+				nameInputEl.focus();
+				nameInputEl.select();
+			}
+		});
+	}
+
+	$effect(() => {
+		if (open) {
+			isEditingName = false;
+		}
+	});
 </script>
 
 {#if session && settings}
 	<Modal
 		bind:open
-		title="Session Settings"
+		dismissable
 		size="lg"
 		outsideclose={false}
 		placement="top-center"
 		class="mt-8"
 	>
-		<div class="flex flex-col gap-2">
-			<!-- General Settings Section -->
-			<div class="card">
-				<Label for="session-name" class="label-text mb-2">Session Name</Label>
-				<Input
-					id="session-name"
-					bind:value={session.name}
-					placeholder="Enter session name"
-					maxlength={60}
-				/>
+		{#snippet header()}
+			<div class="flex items-center gap-1.5 pe-6">
+				{#if isEditingName}
+					<input
+						bind:this={nameInputEl}
+						bind:value={session.name}
+						placeholder="Enter session name"
+						maxlength={60}
+						class="w-64 rounded-md border-b-2 border-primary-500 bg-gray-50 px-1 py-0.5 text-xl font-medium text-gray-900 focus:outline-none dark:bg-gray-700 dark:text-white"
+					/>
+				{:else}
+					<h3 class="flex items-center gap-1.5 px-1 py-0.5 text-xl font-medium text-gray-900 dark:text-white">
+						{session.name || 'Unnamed Session'}
+						<button
+							type="button"
+							onclick={startEditingName}
+							class="rounded-lg p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-white"
+						>
+							<Pencil class="size-4" />
+						</button>
+					</h3>
+				{/if}
 			</div>
+		{/snippet}
+		<div class="flex flex-col gap-2 -mt-4">
+			<!-- General Settings Section -->
 
 			<Tabs
 				bind:selected={selectedSettingsTab}

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -21,7 +21,7 @@
 	import { GROUP_IDS, GROUP_DEFINITIONS } from '$lib/types/group';
 	import { STICKER_COLORS, OPPOSITE_COLOR, type StickerColor } from '$lib/types/stickering';
 	import Update from '$lib/components/Modals/Buttons/Update.svelte';
-	import { CircleQuestionMark, Plus, RotateCcw } from '@lucide/svelte';
+	import { CircleQuestionMark, Plus, RotateCcw, ChevronDown, ChevronRight } from '@lucide/svelte';
 	import TooltipButton from '$lib/components/Modals/TooltipButton.svelte';
 	import EdgeOrientationTooltipPreview from '$lib/components/Session/EdgeOrientationTooltipPreview.svelte';
 	import SessionIndividualCaseSelector from '$lib/components/Session/SessionIndividualCaseSelector.svelte';
@@ -100,6 +100,9 @@
 		globalState.eoOrientedColor !== DEFAULT_EO_ORIENTED_COLOR ||
 			globalState.eoUnorientedColor !== DEFAULT_EO_UNORIENTED_COLOR
 	);
+
+	let showAdvancedTraining = $state(false);
+	let showAdvancedAppearance = $state(false);
 </script>
 
 {#if session && settings}
@@ -210,9 +213,9 @@
 				</TabItem>
 
 				<TabItem title="Training">
-					<div class="mt-4 flex flex-col gap-6">
+					<div class="mt-4 flex flex-col gap-4">
 						<!-- Training Activity Section -->
-						<div class="flex flex-col gap-2">
+						<div class="flex flex-col gap-4">
 							<Label class="text-sm font-semibold">Training Activity</Label>
 
 							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -342,244 +345,227 @@
 							{/if}
 						</div>
 
-						<!-- Frequency Section (Moved Up) -->
-						<div class="flex flex-col gap-2">
-							<Label class="text-sm font-semibold">Case Frequency</Label>
-
-							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-								<!-- Smart Frequency Card -->
-								<!-- svelte-ignore a11y_click_events_have_key_events -->
-								<!-- svelte-ignore a11y_no_static_element_interactions -->
-								<div
-									class="selectable-card flex h-full flex-col {settings.frequencyMode === 'smart'
-										? 'selectable-card-active'
-										: 'selectable-card-inactive'}"
-									onclick={() => (settings.frequencyMode = 'smart')}
-								>
-									<div class="mb-2 flex items-center gap-2">
-										<RadioDot selected={settings.frequencyMode === 'smart'} />
-										<span class="font-medium text-gray-900 dark:text-white">Smart Frequency</span>
-									</div>
-
-									<div
-										class="ml-6 space-y-2 pt-2 {settings.frequencyMode !== 'smart'
-											? 'pointer-events-none opacity-50'
-											: ''}"
-									>
-										<Checkbox
-											bind:checked={settings.smartFrequencySolved}
-											class="text-sm"
-											onclick={(e) => e.stopPropagation()}>Prioritize Unsolved</Checkbox
-										>
-										<Checkbox
-											bind:checked={settings.smartFrequencyTime}
-											class="text-sm"
-											onclick={(e) => e.stopPropagation()}>Prioritize Slow</Checkbox
-										>
-									</div>
-								</div>
-
-								<!-- Recap Mode Card -->
-								<!-- svelte-ignore a11y_click_events_have_key_events -->
-								<!-- svelte-ignore a11y_no_static_element_interactions -->
-								<div
-									class="selectable-card flex h-full flex-col {settings.frequencyMode === 'recap'
-										? 'selectable-card-active'
-										: 'selectable-card-inactive'}"
-									onclick={() => (settings.frequencyMode = 'recap')}
-								>
-									<div class="mb-2 flex items-center gap-2">
-										<RadioDot selected={settings.frequencyMode === 'recap'} />
-										<span class="font-medium text-gray-900 dark:text-white">Recap Mode</span>
-									</div>
-									<p class="ml-6 text-sm text-gray-500 dark:text-gray-400">
-										Cycles through all selected cases once.
-									</p>
-								</div>
-							</div>
-						</div>
-
-						<!-- Configuration & Assistance Grid -->
-						<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-							<!-- Training Setup Column -->
-							<div
-								class="flex flex-col gap-2 {settings.trainMode === 'drill' ? 'sm:col-span-2' : ''}"
+						<!-- Advanced Toggle -->
+						<div class="-mt-2">
+							<button
+								type="button"
+								class="mt-2 flex w-full items-center justify-start gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+								onclick={() => (showAdvancedTraining = !showAdvancedTraining)}
 							>
-								<Label class="text-sm font-semibold">Training Setup</Label>
-								<div
-									class="card h-full {settings.trainMode === 'drill'
-										? 'space-y-4 sm:grid sm:grid-cols-2 sm:gap-4 sm:space-y-0'
-										: 'space-y-4'}"
-								>
-									<div>
-										<Label class="section-label mb-3">Cube Slots</Label>
-										<div class="space-y-2">
-											<Checkbox bind:checked={settings.trainSideSelection.left}>Left Slots</Checkbox
+								{#if showAdvancedTraining}
+									<ChevronDown class="size-4" />
+								{:else}
+									<ChevronRight class="size-4" />
+								{/if}
+								Advanced Settings
+							</button>
+						</div>
+
+						{#if showAdvancedTraining}
+							<!-- Frequency Section (Moved Up) -->
+							<div class="flex flex-col gap-2">
+								<Label class="text-sm font-semibold">Case Frequency</Label>
+
+								<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+									<!-- Smart Frequency Card -->
+									<!-- svelte-ignore a11y_click_events_have_key_events -->
+									<!-- svelte-ignore a11y_no_static_element_interactions -->
+									<div
+										class="selectable-card flex h-full flex-col {settings.frequencyMode === 'smart'
+											? 'selectable-card-active'
+											: 'selectable-card-inactive'}"
+										onclick={() => (settings.frequencyMode = 'smart')}
+									>
+										<div class="mb-2 flex items-center gap-2">
+											<RadioDot selected={settings.frequencyMode === 'smart'} />
+											<span class="font-medium text-gray-900 dark:text-white">Smart Frequency</span>
+										</div>
+
+										<div
+											class="ml-6 space-y-2 pt-2 {settings.frequencyMode !== 'smart'
+												? 'pointer-events-none opacity-50'
+												: ''}"
+										>
+											<Checkbox
+												bind:checked={settings.smartFrequencySolved}
+												class="text-sm"
+												onclick={(e) => e.stopPropagation()}>Prioritize Unsolved</Checkbox
 											>
-											<Checkbox bind:checked={settings.trainSideSelection.right}
-												>Right Slots</Checkbox
+											<Checkbox
+												bind:checked={settings.smartFrequencyTime}
+												class="text-sm"
+												onclick={(e) => e.stopPropagation()}>Prioritize Slow</Checkbox
 											>
 										</div>
 									</div>
 
+									<!-- Recap Mode Card -->
+									<!-- svelte-ignore a11y_click_events_have_key_events -->
+									<!-- svelte-ignore a11y_no_static_element_interactions -->
 									<div
-										class="space-y-3 border-gray-200 dark:border-gray-700 {settings.trainMode ===
-										'drill'
-											? 'border-t pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-4'
-											: 'border-t pt-3'}"
+										class="selectable-card flex h-full flex-col {settings.frequencyMode === 'recap'
+											? 'selectable-card-active'
+											: 'selectable-card-inactive'}"
+										onclick={() => (settings.frequencyMode = 'recap')}
 									>
-										<div>
-											<Checkbox bind:checked={settings.trainAddAuf}>Add Random AUF</Checkbox>
-											<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
-												Adds a random U setup move to the beginning of the algorithm.
-											</p>
+										<div class="mb-2 flex items-center gap-2">
+											<RadioDot selected={settings.frequencyMode === 'recap'} />
+											<span class="font-medium text-gray-900 dark:text-white">Recap Mode</span>
 										</div>
-										<Checkbox bind:checked={settings.trainShowTimer}>Show Timer</Checkbox>
+										<p class="ml-6 text-sm text-gray-500 dark:text-gray-400">
+											Cycles through all selected cases once, tracking your progress with a progress
+											bar.
+										</p>
 									</div>
 								</div>
 							</div>
 
-							<!-- Algorithm Hints Column -->
-							{#if settings.trainMode !== 'drill'}
-								<div class="flex flex-col gap-2">
-									<Label class="text-sm font-semibold">Algorithm Hints</Label>
-									<div class="card h-full space-y-4">
+							<!-- Configuration & Assistance Grid -->
+							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+								<!-- Training Setup Column -->
+								<div
+									class="flex flex-col gap-2 {settings.trainMode === 'drill'
+										? 'sm:col-span-2'
+										: ''}"
+								>
+									<Label class="text-sm font-semibold">Training Setup</Label>
+									<div
+										class="card h-full {settings.trainMode === 'drill'
+											? 'space-y-4 sm:grid sm:grid-cols-2 sm:gap-4 sm:space-y-0'
+											: 'space-y-4'}"
+									>
 										<div>
-											<div class="grid grid-cols-2 gap-2">
-												<!-- svelte-ignore a11y_click_events_have_key_events -->
-												<!-- svelte-ignore a11y_no_static_element_interactions -->
-												<div
-													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
-													{settings.trainHintAlgorithm === 'hidden'
-														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-													onclick={() => (settings.trainHintAlgorithm = 'hidden')}
+											<Label class="section-label mb-3">Cube Slots</Label>
+											<div class="space-y-2">
+												<Checkbox bind:checked={settings.trainSideSelection.left}
+													>Left Slots</Checkbox
 												>
-													<RadioDot selected={settings.trainHintAlgorithm === 'hidden'} />
-													<span class="text-sm text-gray-900 dark:text-white">Hidden</span>
-												</div>
-												<!-- svelte-ignore a11y_click_events_have_key_events -->
-												<!-- svelte-ignore a11y_no_static_element_interactions -->
-												<div
-													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
-													{settings.trainHintAlgorithm === 'step'
-														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-													onclick={() => (settings.trainHintAlgorithm = 'step')}
+												<Checkbox bind:checked={settings.trainSideSelection.right}
+													>Right Slots</Checkbox
 												>
-													<RadioDot selected={settings.trainHintAlgorithm === 'step'} />
-													<span class="text-sm text-gray-900 dark:text-white">Step-by-step</span>
-												</div>
-												<!-- svelte-ignore a11y_click_events_have_key_events -->
-												<!-- svelte-ignore a11y_no_static_element_interactions -->
-												<div
-													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
-													{settings.trainHintAlgorithm === 'allAtOnce'
-														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-													onclick={() => (settings.trainHintAlgorithm = 'allAtOnce')}
-												>
-													<RadioDot selected={settings.trainHintAlgorithm === 'allAtOnce'} />
-													<span class="text-sm text-gray-900 dark:text-white">All at once</span>
-												</div>
-												<!-- svelte-ignore a11y_click_events_have_key_events -->
-												<!-- svelte-ignore a11y_no_static_element_interactions -->
-												<div
-													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
-													{settings.trainHintAlgorithm === 'always'
-														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-													onclick={() => (settings.trainHintAlgorithm = 'always')}
-												>
-													<RadioDot selected={settings.trainHintAlgorithm === 'always'} />
-													<span class="text-sm text-gray-900 dark:text-white">Always show</span>
-												</div>
 											</div>
 										</div>
 
-										<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
-											<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
-											<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-												This setting only applies when training with a connected smart cube.
-											</p>
-											<div class="grid grid-cols-2 gap-2">
-												<!-- svelte-ignore a11y_click_events_have_key_events -->
-												<!-- svelte-ignore a11y_no_static_element_interactions -->
-												<div
-													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
-													{settings.smartHintBehavior === 'auto'
-														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-													onclick={() => (settings.smartHintBehavior = 'auto')}
-												>
-													<RadioDot selected={settings.smartHintBehavior === 'auto'} />
-													<span class="text-sm text-gray-900 dark:text-white">Auto-track</span>
+										<div
+											class="space-y-3 border-gray-200 dark:border-gray-700 {settings.trainMode ===
+											'drill'
+												? 'border-t pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-4'
+												: 'border-t pt-3'}"
+										>
+											<div>
+												<Checkbox bind:checked={settings.trainAddAuf}>Add Random AUF</Checkbox>
+												<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
+													Adds a random U setup move to the beginning of the algorithm.
+												</p>
+											</div>
+											<Checkbox bind:checked={settings.trainShowTimer}>Show Timer</Checkbox>
+										</div>
+									</div>
+								</div>
+
+								<!-- Algorithm Hints Column -->
+								{#if settings.trainMode !== 'drill'}
+									<div class="flex flex-col gap-2">
+										<Label class="text-sm font-semibold">Algorithm Hints</Label>
+										<div class="card h-full space-y-4">
+											<div>
+												<div class="grid grid-cols-2 gap-2">
+													<!-- svelte-ignore a11y_click_events_have_key_events -->
+													<!-- svelte-ignore a11y_no_static_element_interactions -->
+													<div
+														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													{settings.trainHintAlgorithm === 'hidden'
+															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+														onclick={() => (settings.trainHintAlgorithm = 'hidden')}
+													>
+														<RadioDot selected={settings.trainHintAlgorithm === 'hidden'} />
+														<span class="text-sm text-gray-900 dark:text-white">Hidden</span>
+													</div>
+													<!-- svelte-ignore a11y_click_events_have_key_events -->
+													<!-- svelte-ignore a11y_no_static_element_interactions -->
+													<div
+														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													{settings.trainHintAlgorithm === 'step'
+															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+														onclick={() => (settings.trainHintAlgorithm = 'step')}
+													>
+														<RadioDot selected={settings.trainHintAlgorithm === 'step'} />
+														<span class="text-sm text-gray-900 dark:text-white">Step-by-step</span>
+													</div>
+													<!-- svelte-ignore a11y_click_events_have_key_events -->
+													<!-- svelte-ignore a11y_no_static_element_interactions -->
+													<div
+														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													{settings.trainHintAlgorithm === 'allAtOnce'
+															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+														onclick={() => (settings.trainHintAlgorithm = 'allAtOnce')}
+													>
+														<RadioDot selected={settings.trainHintAlgorithm === 'allAtOnce'} />
+														<span class="text-sm text-gray-900 dark:text-white">All at once</span>
+													</div>
+													<!-- svelte-ignore a11y_click_events_have_key_events -->
+													<!-- svelte-ignore a11y_no_static_element_interactions -->
+													<div
+														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													{settings.trainHintAlgorithm === 'always'
+															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+														onclick={() => (settings.trainHintAlgorithm = 'always')}
+													>
+														<RadioDot selected={settings.trainHintAlgorithm === 'always'} />
+														<span class="text-sm text-gray-900 dark:text-white">Always show</span>
+													</div>
 												</div>
-												<!-- svelte-ignore a11y_click_events_have_key_events -->
-												<!-- svelte-ignore a11y_no_static_element_interactions -->
-												<div
-													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+											</div>
+
+											<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
+												<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
+												<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+													This setting only applies when training with a connected smart cube.
+												</p>
+												<div class="grid grid-cols-2 gap-2">
+													<!-- svelte-ignore a11y_click_events_have_key_events -->
+													<!-- svelte-ignore a11y_no_static_element_interactions -->
+													<div
+														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													{settings.smartHintBehavior === 'auto'
+															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+														onclick={() => (settings.smartHintBehavior = 'auto')}
+													>
+														<RadioDot selected={settings.smartHintBehavior === 'auto'} />
+														<span class="text-sm text-gray-900 dark:text-white">Auto-track</span>
+													</div>
+													<!-- svelte-ignore a11y_click_events_have_key_events -->
+													<!-- svelte-ignore a11y_no_static_element_interactions -->
+													<div
+														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
 													{settings.smartHintBehavior === 'manual'
-														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-													onclick={() => (settings.smartHintBehavior = 'manual')}
-												>
-													<RadioDot selected={settings.smartHintBehavior === 'manual'} />
-													<span class="text-sm text-gray-900 dark:text-white">Manual clicks</span>
+															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+														onclick={() => (settings.smartHintBehavior = 'manual')}
+													>
+														<RadioDot selected={settings.smartHintBehavior === 'manual'} />
+														<span class="text-sm text-gray-900 dark:text-white">Manual clicks</span>
+													</div>
 												</div>
 											</div>
 										</div>
 									</div>
-								</div>
-							{/if}
-						</div>
+								{/if}
+							</div>
+						{/if}
 					</div>
 				</TabItem>
 
 				<TabItem title="Appearance">
-					<div class="mt-4 flex flex-col gap-6">
+					<div class="mt-4 flex flex-col gap-4">
 						<!-- Cube Appearance Section -->
 						<div class="flex flex-col gap-4">
-							<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-								<!-- Cross Color -->
-								<div class="card">
-									<Label class="section-label mb-3">Cross Color</Label>
-									<div class="grid grid-cols-2 gap-2">
-										{#each STICKER_COLORS as color}
-											<Checkbox bind:group={settings.crossColor} value={color}>
-												{color.charAt(0).toUpperCase() + color.slice(1)}
-											</Checkbox>
-										{/each}
-									</div>
-								</div>
-
-								<!-- Front Color -->
-								<div class="card">
-									<Label class="section-label mb-3">Front Color</Label>
-									<div class="grid grid-cols-2 gap-2">
-										{#each STICKER_COLORS as color}
-											{@const isDisabled =
-												settings.crossColor.length > 1 ||
-												(settings.crossColor.length === 1 &&
-													!settings.crossColor.every(
-														(c: any) => c !== color && OPPOSITE_COLOR[c as StickerColor] !== color
-													))}
-											<Checkbox
-												bind:group={settings.frontColor}
-												value={color}
-												disabled={isDisabled}
-											>
-												{color.charAt(0).toUpperCase() + color.slice(1)}
-											</Checkbox>
-										{/each}
-									</div>
-									{#if settings.crossColor.length > 1}
-										<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-											Randomized when multiple cross colors selected.
-										</p>
-									{/if}
-								</div>
-
+							<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
 								<!-- Sticker Style -->
 								<div class="card">
 									<Label class="section-label mb-3">Stickering Style</Label>
@@ -746,89 +732,148 @@
 										</div>
 									</div>
 								</div>
+							</div>
 
-								<!-- Edge Orientation -->
-								<div class="card">
-									<Label class="mb-3 text-sm font-semibold">Edge Orientation</Label>
-									<div class="space-y-4">
-										<div class="flex items-center gap-2">
-											<Checkbox bind:checked={settings.trainLearnEO}
-												>Learn Edge Orientation</Checkbox
-											>
-											<Button
-												id="btn-edge-orientation-help"
-												class="bg-transparent p-1 hover:bg-transparent focus:bg-transparent dark:bg-transparent dark:hover:bg-transparent dark:focus:bg-transparent"
-												type="button"
-												onclick={(e: MouseEvent) => e.stopPropagation()}
-											>
-												<CircleQuestionMark class="text-primary-600" />
-											</Button>
-											<Tooltip
-												triggeredBy="#btn-edge-orientation-help"
-												trigger="click"
-												class="p-3"
-												placement="left"
-											>
-												<div class="space-y-3">
-													<p class="max-w-xs text-xs text-gray-600 dark:text-gray-300">
-														When enabled, highlight F2L edges by orientation
-													</p>
-													<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-														<EdgeOrientationTooltipPreview
-															caseId={1}
-															description="Oriented edge"
-															class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/80"
+							<!-- Advanced Toggle -->
+							<div class="-mt-2">
+								<button
+									type="button"
+									class="mt-2 flex w-full items-center justify-start gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+									onclick={() => (showAdvancedAppearance = !showAdvancedAppearance)}
+								>
+									{#if showAdvancedAppearance}
+										<ChevronDown class="size-4" />
+									{:else}
+										<ChevronRight class="size-4" />
+									{/if}
+									Advanced Settings
+								</button>
+							</div>
+
+							{#if showAdvancedAppearance}
+								<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+									<!-- Cross Color -->
+									<div class="card">
+										<Label class="section-label mb-3">Cross Color</Label>
+										<div class="grid grid-cols-2 gap-2">
+											{#each STICKER_COLORS as color}
+												<Checkbox bind:group={settings.crossColor} value={color}>
+													{color.charAt(0).toUpperCase() + color.slice(1)}
+												</Checkbox>
+											{/each}
+										</div>
+									</div>
+
+									<!-- Front Color -->
+									<div class="card">
+										<Label class="section-label mb-3">Front Color</Label>
+										<div class="grid grid-cols-2 gap-2">
+											{#each STICKER_COLORS as color}
+												{@const isDisabled =
+													settings.crossColor.length > 1 ||
+													(settings.crossColor.length === 1 &&
+														!settings.crossColor.every(
+															(c: any) => c !== color && OPPOSITE_COLOR[c as StickerColor] !== color
+														))}
+												<Checkbox
+													bind:group={settings.frontColor}
+													value={color}
+													disabled={isDisabled}
+												>
+													{color.charAt(0).toUpperCase() + color.slice(1)}
+												</Checkbox>
+											{/each}
+										</div>
+										{#if settings.crossColor.length > 1}
+											<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+												Randomized when multiple cross colors selected.
+											</p>
+										{/if}
+									</div>
+
+									<!-- Edge Orientation -->
+									<div class="card">
+										<Label class="mb-3 text-sm font-semibold">Edge Orientation</Label>
+										<div class="space-y-4">
+											<div class="flex items-center gap-2">
+												<Checkbox bind:checked={settings.trainLearnEO}
+													>Learn Edge Orientation</Checkbox
+												>
+												<Button
+													id="btn-edge-orientation-help"
+													class="bg-transparent p-1 hover:bg-transparent focus:bg-transparent dark:bg-transparent dark:hover:bg-transparent dark:focus:bg-transparent"
+													type="button"
+													onclick={(e: MouseEvent) => e.stopPropagation()}
+												>
+													<CircleQuestionMark class="text-primary-600" />
+												</Button>
+												<Tooltip
+													triggeredBy="#btn-edge-orientation-help"
+													trigger="click"
+													class="p-3"
+													placement="left"
+												>
+													<div class="space-y-3">
+														<p class="max-w-xs text-xs text-gray-600 dark:text-gray-300">
+															When enabled, highlight F2L edges by orientation
+														</p>
+														<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+															<EdgeOrientationTooltipPreview
+																caseId={1}
+																description="Oriented edge"
+																class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/80"
+															/>
+															<EdgeOrientationTooltipPreview
+																caseId={11}
+																description="Unoriented edge"
+																class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/80"
+															/>
+														</div>
+													</div>
+												</Tooltip>
+											</div>
+											{#if settings.trainLearnEO}
+												<div
+													class="grid grid-cols-2 gap-4 border-t border-gray-200 pt-3 dark:border-gray-700"
+												>
+													<div>
+														<Label class="mb-2 text-xs">Oriented Color</Label>
+														<input
+															type="color"
+															bind:value={globalState.eoOrientedColor}
+															class="h-8 w-full cursor-pointer rounded border border-gray-300 p-0"
 														/>
-														<EdgeOrientationTooltipPreview
-															caseId={11}
-															description="Unoriented edge"
-															class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/80"
+													</div>
+													<div>
+														<Label class="mb-2 text-xs">Unoriented Color</Label>
+														<input
+															type="color"
+															bind:value={globalState.eoUnorientedColor}
+															class="h-8 w-full cursor-pointer rounded border border-gray-300 p-0"
 														/>
 													</div>
 												</div>
-											</Tooltip>
-										</div>
-										{#if settings.trainLearnEO}
-											<div
-												class="grid grid-cols-2 gap-4 border-t border-gray-200 pt-3 dark:border-gray-700"
-											>
-												<div>
-													<Label class="mb-2 text-xs">Oriented Color</Label>
-													<input
-														type="color"
-														bind:value={globalState.eoOrientedColor}
-														class="h-8 w-full cursor-pointer rounded border border-gray-300 p-0"
-													/>
-												</div>
-												<div>
-													<Label class="mb-2 text-xs">Unoriented Color</Label>
-													<input
-														type="color"
-														bind:value={globalState.eoUnorientedColor}
-														class="h-8 w-full cursor-pointer rounded border border-gray-300 p-0"
-													/>
-												</div>
-											</div>
-											{#if hasChangedEOColors}
-												<div class="mt-4 flex justify-end">
-													<Button
-														size="xs"
-														color="alternative"
-														onclick={() => {
-															globalState.eoOrientedColor = DEFAULT_EO_ORIENTED_COLOR;
-															globalState.eoUnorientedColor = DEFAULT_EO_UNORIENTED_COLOR;
-														}}
-														class="gap-1.5"
-													>
-														<RotateCcw size={14} />
-														Reset to Default
-													</Button>
-												</div>
+												{#if hasChangedEOColors}
+													<div class="mt-4 flex justify-end">
+														<Button
+															size="xs"
+															color="alternative"
+															onclick={() => {
+																globalState.eoOrientedColor = DEFAULT_EO_ORIENTED_COLOR;
+																globalState.eoUnorientedColor = DEFAULT_EO_UNORIENTED_COLOR;
+															}}
+															class="gap-1.5"
+														>
+															<RotateCcw size={14} />
+															Reset to Default
+														</Button>
+													</div>
+												{/if}
 											{/if}
-										{/if}
+										</div>
 									</div>
 								</div>
-							</div>
+							{/if}
 						</div>
 					</div>
 				</TabItem>

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -472,6 +472,39 @@
 												</div>
 											</div>
 										</div>
+
+										<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
+											<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
+											<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+												This setting only applies when training with a connected smart cube.
+											</p>
+											<div class="grid grid-cols-2 gap-2">
+												<!-- svelte-ignore a11y_click_events_have_key_events -->
+												<!-- svelte-ignore a11y_no_static_element_interactions -->
+												<div
+													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													{settings.smartHintBehavior === 'auto'
+														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+													onclick={() => (settings.smartHintBehavior = 'auto')}
+												>
+													<RadioDot selected={settings.smartHintBehavior === 'auto'} />
+													<span class="text-sm text-gray-900 dark:text-white">Auto-track</span>
+												</div>
+												<!-- svelte-ignore a11y_click_events_have_key_events -->
+												<!-- svelte-ignore a11y_no_static_element_interactions -->
+												<div
+													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													{settings.smartHintBehavior === 'manual'
+														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+													onclick={() => (settings.smartHintBehavior = 'manual')}
+												>
+													<RadioDot selected={settings.smartHintBehavior === 'manual'} />
+													<span class="text-sm text-gray-900 dark:text-white">Manual clicks</span>
+												</div>
+											</div>
+										</div>
 									{/if}
 
 									<div class="space-y-3 border-t border-gray-200 pt-3 dark:border-gray-700">

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -421,7 +421,19 @@
 									{#if settings.trainMode !== 'drill'}
 										<div>
 											<Label class="section-label mb-3">Algorithm Hint</Label>
-											<div class="grid grid-cols-3 gap-2">
+											<div class="grid grid-cols-2 gap-2">
+												<!-- svelte-ignore a11y_click_events_have_key_events -->
+												<!-- svelte-ignore a11y_no_static_element_interactions -->
+												<div
+													class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													{settings.trainHintAlgorithm === 'hidden'
+														? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+														: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+													onclick={() => (settings.trainHintAlgorithm = 'hidden')}
+												>
+													<RadioDot selected={settings.trainHintAlgorithm === 'hidden'} />
+													<span class="text-sm text-gray-900 dark:text-white">Hidden</span>
+												</div>
 												<!-- svelte-ignore a11y_click_events_have_key_events -->
 												<!-- svelte-ignore a11y_no_static_element_interactions -->
 												<div

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -100,9 +100,6 @@
 		globalState.eoOrientedColor !== DEFAULT_EO_ORIENTED_COLOR ||
 			globalState.eoUnorientedColor !== DEFAULT_EO_UNORIENTED_COLOR
 	);
-
-	let showAdvancedTraining = $state(false);
-	let showAdvancedAppearance = $state(false);
 </script>
 
 {#if session && settings}
@@ -350,9 +347,9 @@
 							<button
 								type="button"
 								class="mt-2 flex w-full items-center justify-start gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-								onclick={() => (showAdvancedTraining = !showAdvancedTraining)}
+								onclick={() => (globalState.showAdvancedTraining = !globalState.showAdvancedTraining)}
 							>
-								{#if showAdvancedTraining}
+								{#if globalState.showAdvancedTraining}
 									<ChevronDown class="size-4" />
 								{:else}
 									<ChevronRight class="size-4" />
@@ -361,7 +358,7 @@
 							</button>
 						</div>
 
-						{#if showAdvancedTraining}
+						{#if globalState.showAdvancedTraining}
 							<!-- Frequency Section (Moved Up) -->
 							<div class="flex flex-col gap-2">
 								<Label class="text-sm font-semibold">Case Frequency</Label>
@@ -739,9 +736,9 @@
 								<button
 									type="button"
 									class="mt-2 flex w-full items-center justify-start gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-									onclick={() => (showAdvancedAppearance = !showAdvancedAppearance)}
+									onclick={() => (globalState.showAdvancedAppearance = !globalState.showAdvancedAppearance)}
 								>
-									{#if showAdvancedAppearance}
+									{#if globalState.showAdvancedAppearance}
 										<ChevronDown class="size-4" />
 									{:else}
 										<ChevronRight class="size-4" />
@@ -750,7 +747,7 @@
 								</button>
 							</div>
 
-							{#if showAdvancedAppearance}
+							{#if globalState.showAdvancedAppearance}
 								<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 									<!-- Cross Color -->
 									<div class="card">

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -552,36 +552,50 @@
 														<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
 															<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
 															<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-																This setting only applies when training with a connected smart cube.
+																Only applies when smart cube is connected.
 															</p>
 															<div class="grid grid-cols-2 gap-2">
 																<!-- svelte-ignore a11y_click_events_have_key_events -->
 																<!-- svelte-ignore a11y_no_static_element_interactions -->
 																<div
-																	class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+																	class="flex cursor-pointer items-start gap-2 rounded-lg border p-3 transition-colors
 														{settings.smartHintBehavior === 'auto'
 																		? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
 																		: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
 																	onclick={() => (settings.smartHintBehavior = 'auto')}
 																>
-																	<RadioDot selected={settings.smartHintBehavior === 'auto'} />
-																	<span class="text-sm text-gray-900 dark:text-white"
-																		>Auto-track</span
-																	>
+																	<div class="mt-0.5">
+																		<RadioDot selected={settings.smartHintBehavior === 'auto'} />
+																	</div>
+																	<div class="flex flex-col">
+																		<span class="text-sm font-medium text-gray-900 dark:text-white"
+																			>Smart Tracking</span
+																		>
+																		<span class="mt-0.5 text-xs text-gray-500 dark:text-gray-400"
+																			>Follows your moves and corrects you if needed.</span
+																		>
+																	</div>
 																</div>
 																<!-- svelte-ignore a11y_click_events_have_key_events -->
 																<!-- svelte-ignore a11y_no_static_element_interactions -->
 																<div
-																	class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+																	class="flex cursor-pointer items-start gap-2 rounded-lg border p-3 transition-colors
 														{settings.smartHintBehavior === 'manual'
 																		? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
 																		: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
 																	onclick={() => (settings.smartHintBehavior = 'manual')}
 																>
-																	<RadioDot selected={settings.smartHintBehavior === 'manual'} />
-																	<span class="text-sm text-gray-900 dark:text-white"
-																		>Manual clicks</span
-																	>
+																	<div class="mt-0.5">
+																		<RadioDot selected={settings.smartHintBehavior === 'manual'} />
+																	</div>
+																	<div class="flex flex-col">
+																		<span class="text-sm font-medium text-gray-900 dark:text-white"
+																			>Manual Mode</span
+																		>
+																		<span class="mt-0.5 text-xs text-gray-500 dark:text-gray-400"
+																			>Does not track moves.</span
+																		>
+																	</div>
 																</div>
 															</div>
 														</div>

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -234,6 +234,12 @@
 									</p>
 
 									<div class="ml-6 border-t border-gray-200 pt-3 dark:border-gray-700">
+										<Checkbox bind:checked={settings.scrambleYourself}>
+											Scramble Yourself
+										</Checkbox>
+										<p class="mt-1 ml-6 mb-3 text-xs text-gray-500 dark:text-gray-400">
+											Scramble your smart cube yourself. Requires Smart Cube.
+										</p>
 										<p class="text-sm text-gray-600 dark:text-gray-400">
 											💡 Smart cube support activates automatically when connected.
 										</p>
@@ -291,6 +297,34 @@
 										<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
 											The virtual cube will disappear once you start solving, forcing you to rely on
 											memory.
+										</p>
+									</div>
+								</div>
+							{/if}
+							{#if settings.trainMode === 'classic' && settings.scrambleYourself}
+								<div class="card">
+									<div class="mb-4 flex items-center justify-between">
+										<Label class="section-label">Scramble Flow</Label>
+										<span class="text-sm font-medium text-gray-900 dark:text-gray-100"
+											>{settings.scrambleCountdownDuration}s delay</span
+										>
+									</div>
+									<Range
+										id="scramble-delay"
+										min={0}
+										max={5}
+										step={0.25}
+										bind:value={settings.scrambleCountdownDuration}
+									/>
+									<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+										Time between completing scramble and seeing the case.
+									</p>
+									<div class="mt-4 border-t border-gray-200 pt-3 dark:border-gray-700">
+										<Checkbox bind:checked={settings.scrambleShowCube}>
+											Show Cube While Scrambling
+										</Checkbox>
+										<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
+											Display the virtual cube updating as you scramble. When off, the cube is hidden until you start solving.
 										</p>
 									</div>
 								</div>

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -212,7 +212,7 @@
 				<TabItem title="Training">
 					<div class="mt-4 flex flex-col gap-6">
 						<!-- Training Activity Section -->
-						<div class="flex flex-col gap-4">
+						<div class="flex flex-col gap-2">
 							<Label class="text-sm font-semibold">Training Activity</Label>
 
 							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -343,7 +343,7 @@
 						</div>
 
 						<!-- Frequency Section (Moved Up) -->
-						<div class="flex flex-col gap-4">
+						<div class="flex flex-col gap-2">
 							<Label class="text-sm font-semibold">Case Frequency</Label>
 
 							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -401,26 +401,39 @@
 
 						<!-- Configuration & Assistance Grid -->
 						<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-							<!-- Configuration (Cube Slots) -->
-							<div class="flex flex-col gap-4">
-								<Label class="text-sm font-semibold">Configuration</Label>
-								<div class="card h-full">
-									<Label class="mb-3 text-sm font-semibold">Cube Slots</Label>
-									<div class="space-y-2">
-										<Checkbox bind:checked={settings.trainSideSelection.left}>Left Slots</Checkbox>
-										<Checkbox bind:checked={settings.trainSideSelection.right}>Right Slots</Checkbox
-										>
+							<!-- Training Setup Column -->
+							<div class="flex flex-col gap-2">
+								<Label class="text-sm font-semibold">Training Setup</Label>
+								<div class="card h-full space-y-4">
+									<div>
+										<Label class="section-label mb-3">Cube Slots</Label>
+										<div class="space-y-2">
+											<Checkbox bind:checked={settings.trainSideSelection.left}>Left Slots</Checkbox
+											>
+											<Checkbox bind:checked={settings.trainSideSelection.right}
+												>Right Slots</Checkbox
+											>
+										</div>
+									</div>
+
+									<div class="space-y-3 border-t border-gray-200 pt-3 dark:border-gray-700">
+										<div>
+											<Checkbox bind:checked={settings.trainAddAuf}>Add Random AUF</Checkbox>
+											<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
+												Adds a random U setup move to the beginning of the algorithm.
+											</p>
+										</div>
+										<Checkbox bind:checked={settings.trainShowTimer}>Show Timer</Checkbox>
 									</div>
 								</div>
 							</div>
 
-							<!-- Assistance & Tools -->
-							<div class="flex flex-col gap-4">
-								<Label class="text-sm font-semibold">Assistance & Tools</Label>
+							<!-- Algorithm Hints Column -->
+							<div class="flex flex-col gap-2">
+								<Label class="text-sm font-semibold">Algorithm Hints</Label>
 								<div class="card h-full space-y-4">
 									{#if settings.trainMode !== 'drill'}
 										<div>
-											<Label class="section-label mb-3">Algorithm Hint</Label>
 											<div class="grid grid-cols-2 gap-2">
 												<!-- svelte-ignore a11y_click_events_have_key_events -->
 												<!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -506,16 +519,6 @@
 											</div>
 										</div>
 									{/if}
-
-									<div class="space-y-3 border-t border-gray-200 pt-3 dark:border-gray-700">
-										<div>
-											<Checkbox bind:checked={settings.trainAddAuf}>Add Random AUF</Checkbox>
-											<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
-												Adds a random U setup move to the beginning of the algorithm.
-											</p>
-										</div>
-										<Checkbox bind:checked={settings.trainShowTimer}>Show Timer</Checkbox>
-									</div>
 								</div>
 							</div>
 						</div>

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -402,9 +402,15 @@
 						<!-- Configuration & Assistance Grid -->
 						<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
 							<!-- Training Setup Column -->
-							<div class="flex flex-col gap-2">
+							<div
+								class="flex flex-col gap-2 {settings.trainMode === 'drill' ? 'sm:col-span-2' : ''}"
+							>
 								<Label class="text-sm font-semibold">Training Setup</Label>
-								<div class="card h-full space-y-4">
+								<div
+									class="card h-full {settings.trainMode === 'drill'
+										? 'space-y-4 sm:grid sm:grid-cols-2 sm:gap-4 sm:space-y-0'
+										: 'space-y-4'}"
+								>
 									<div>
 										<Label class="section-label mb-3">Cube Slots</Label>
 										<div class="space-y-2">
@@ -416,7 +422,12 @@
 										</div>
 									</div>
 
-									<div class="space-y-3 border-t border-gray-200 pt-3 dark:border-gray-700">
+									<div
+										class="space-y-3 border-gray-200 dark:border-gray-700 {settings.trainMode ===
+										'drill'
+											? 'border-t pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-4'
+											: 'border-t pt-3'}"
+									>
 										<div>
 											<Checkbox bind:checked={settings.trainAddAuf}>Add Random AUF</Checkbox>
 											<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
@@ -429,10 +440,10 @@
 							</div>
 
 							<!-- Algorithm Hints Column -->
-							<div class="flex flex-col gap-2">
-								<Label class="text-sm font-semibold">Algorithm Hints</Label>
-								<div class="card h-full space-y-4">
-									{#if settings.trainMode !== 'drill'}
+							{#if settings.trainMode !== 'drill'}
+								<div class="flex flex-col gap-2">
+									<Label class="text-sm font-semibold">Algorithm Hints</Label>
+									<div class="card h-full space-y-4">
 										<div>
 											<div class="grid grid-cols-2 gap-2">
 												<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -518,9 +529,9 @@
 												</div>
 											</div>
 										</div>
-									{/if}
+									</div>
 								</div>
-							</div>
+							{/if}
 						</div>
 					</div>
 				</TabItem>

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -234,10 +234,9 @@
 									</p>
 
 									<div class="ml-6 border-t border-gray-200 pt-3 dark:border-gray-700">
-										<Checkbox bind:checked={settings.scrambleYourself}>
-											Scramble Yourself
-										</Checkbox>
-										<p class="mt-1 ml-6 mb-3 text-xs text-gray-500 dark:text-gray-400">
+										<Checkbox bind:checked={settings.scrambleYourself}>Scramble Smart Cube</Checkbox
+										>
+										<p class="mt-1 mb-3 ml-6 text-xs text-gray-500 dark:text-gray-400">
 											Scramble your smart cube yourself. Requires Smart Cube.
 										</p>
 										<p class="text-sm text-gray-600 dark:text-gray-400">
@@ -274,22 +273,28 @@
 							</div>
 							{#if settings.trainMode === 'drill'}
 								<div class="card">
-									<div class="mb-4 flex items-center justify-between">
-										<Label class="section-label">Drill Flow</Label>
-										<span class="text-sm font-medium text-gray-900 dark:text-gray-100"
-											>{settings.drillTimeBetweenCases}s delay</span
-										>
+									<Label class="section-label mb-4">Drill Settings</Label>
+
+									<div>
+										<div class="mb-2 flex items-center justify-between">
+											<Label class="text-sm font-semibold">Transition Delay</Label>
+											<span class="text-sm font-medium text-gray-900 dark:text-gray-100">
+												{settings.drillTimeBetweenCases}s
+											</span>
+										</div>
+
+										<Range
+											id="drill-delay"
+											min={0}
+											max={5}
+											step={0.25}
+											bind:value={settings.drillTimeBetweenCases}
+										/>
+
+										<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+											Time between solving a case and seeing the next one.
+										</p>
 									</div>
-									<Range
-										id="drill-delay"
-										min={0}
-										max={5}
-										step={0.25}
-										bind:value={settings.drillTimeBetweenCases}
-									/>
-									<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-										Time between solving a case and seeing the next one.
-									</p>
 									<div class="mt-4 border-t border-gray-200 pt-3 dark:border-gray-700">
 										<Checkbox bind:checked={settings.drillHideTwistyPlayer}>
 											Hide Cube After First Move
@@ -303,28 +308,34 @@
 							{/if}
 							{#if settings.trainMode === 'classic' && settings.scrambleYourself}
 								<div class="card">
-									<div class="mb-4 flex items-center justify-between">
-										<Label class="section-label">Scramble Flow</Label>
-										<span class="text-sm font-medium text-gray-900 dark:text-gray-100"
-											>{settings.scrambleCountdownDuration}s delay</span
-										>
+									<Label class="section-label mb-4">Scramble Settings</Label>
+
+									<div>
+										<div class="mb-2 flex items-center justify-between">
+											<Label class="text-sm font-semibold">Transition Delay</Label>
+											<span class="text-sm font-medium text-gray-900 dark:text-gray-100">
+												{settings.scrambleCountdownDuration}s
+											</span>
+										</div>
+
+										<Range
+											id="scramble-delay"
+											min={0}
+											max={5}
+											step={0.25}
+											bind:value={settings.scrambleCountdownDuration}
+										/>
+
+										<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+											Time between completing scramble and seeing the case.
+										</p>
 									</div>
-									<Range
-										id="scramble-delay"
-										min={0}
-										max={5}
-										step={0.25}
-										bind:value={settings.scrambleCountdownDuration}
-									/>
-									<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-										Time between completing scramble and seeing the case.
-									</p>
 									<div class="mt-4 border-t border-gray-200 pt-3 dark:border-gray-700">
 										<Checkbox bind:checked={settings.scrambleShowCube}>
-											Show Cube While Scrambling
+											Show F2L While Scrambling
 										</Checkbox>
 										<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
-											Display the virtual cube updating as you scramble. When off, the cube is hidden until you start solving.
+											When disabled, the virtual cube hides all pieces except the centers.
 										</p>
 									</div>
 								</div>
@@ -451,14 +462,12 @@
 										</div>
 									{/if}
 
-									<div class="space-y-2 border-t border-gray-200 pt-3 dark:border-gray-700">
-										<div class="flex items-center gap-2">
+									<div class="space-y-3 border-t border-gray-200 pt-3 dark:border-gray-700">
+										<div>
 											<Checkbox bind:checked={settings.trainAddAuf}>Add Random AUF</Checkbox>
-											<TooltipButton
-												id="btn-session-settings-auf"
-												tooltip="Adds a random U move to the end of the scramble"
-												icon={CircleQuestionMark}
-											/>
+											<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
+												Adds a random U setup move to the beginning of the algorithm.
+											</p>
 										</div>
 										<Checkbox bind:checked={settings.trainShowTimer}>Show Timer</Checkbox>
 									</div>

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -21,7 +21,7 @@
 	import { GROUP_IDS, GROUP_DEFINITIONS } from '$lib/types/group';
 	import { STICKER_COLORS, OPPOSITE_COLOR, type StickerColor } from '$lib/types/stickering';
 	import Update from '$lib/components/Modals/Buttons/Update.svelte';
-	import { CircleQuestionMark, Plus, RotateCcw, ChevronDown, ChevronRight } from '@lucide/svelte';
+	import { CircleQuestionMark, Plus, RotateCcw, ChevronDown, ChevronRight, Settings } from '@lucide/svelte';
 	import TooltipButton from '$lib/components/Modals/TooltipButton.svelte';
 	import EdgeOrientationTooltipPreview from '$lib/components/Session/EdgeOrientationTooltipPreview.svelte';
 	import SessionIndividualCaseSelector from '$lib/components/Session/SessionIndividualCaseSelector.svelte';
@@ -273,7 +273,7 @@
 									</p>
 
 									<div class="ml-6 border-t border-gray-200 pt-3 dark:border-gray-700">
-										<div class="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400">
+										<div class="flex items-center gap-2 text-sm text-purple-600 dark:text-purple-400">
 											<span class="font-medium">Requires Smart Cube</span>
 										</div>
 									</div>
@@ -350,11 +350,11 @@
 							{/if}
 						</div>
 
-						<!-- Advanced Toggle -->
-						<div class="-mt-2">
+						<!-- Advanced Settings Well -->
+						<div class="-mt-2 rounded-xl border border-gray-200 bg-gray-50/50 shadow-sm dark:border-gray-700 dark:bg-gray-800/40">
 							<button
 								type="button"
-								class="mt-2 flex w-full items-center justify-start gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+								class="flex w-full items-center justify-start gap-2 p-4 text-sm font-medium text-blue-600 transition-colors hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
 								onclick={() => (globalState.showAdvancedTraining = !globalState.showAdvancedTraining)}
 							>
 								{#if globalState.showAdvancedTraining}
@@ -364,12 +364,12 @@
 								{/if}
 								Advanced Settings
 							</button>
-						</div>
 
-						{#if globalState.showAdvancedTraining}
-							<!-- Frequency Section (Moved Up) -->
-							<div class="flex flex-col gap-2">
-								<Label class="text-sm font-semibold">Case Frequency</Label>
+							{#if globalState.showAdvancedTraining}
+								<div class="flex flex-col gap-4 border-t border-gray-200 p-4 dark:border-gray-700">
+									<!-- Frequency Section (Moved Up) -->
+									<div class="flex flex-col gap-2">
+										<Label class="text-sm font-semibold">Case Frequency</Label>
 
 								<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
 									<!-- Smart Frequency Card -->
@@ -562,9 +562,11 @@
 									</div>
 								{/if}
 							</div>
-						{/if}
+						</div>
+					{/if}
 					</div>
-				</TabItem>
+				</div>
+			</TabItem>
 
 				<TabItem key="appearance" title="Appearance">
 					<div class="mt-4 flex flex-col gap-4">
@@ -739,11 +741,11 @@
 								</div>
 							</div>
 
-							<!-- Advanced Toggle -->
-							<div class="-mt-2">
+							<!-- Advanced Settings Well -->
+							<div class="-mt-2 rounded-xl border border-gray-200 bg-gray-50/50 shadow-sm dark:border-gray-700 dark:bg-gray-800/40">
 								<button
 									type="button"
-									class="mt-2 flex w-full items-center justify-start gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+									class="flex w-full items-center justify-start gap-2 p-4 text-sm font-medium text-blue-600 transition-colors hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
 									onclick={() => (globalState.showAdvancedAppearance = !globalState.showAdvancedAppearance)}
 								>
 									{#if globalState.showAdvancedAppearance}
@@ -753,12 +755,11 @@
 									{/if}
 									Advanced Settings
 								</button>
-							</div>
 
-							{#if globalState.showAdvancedAppearance}
-								<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-									<!-- Cross Color -->
-									<div class="card">
+								{#if globalState.showAdvancedAppearance}
+									<div class="grid grid-cols-1 gap-4 border-t border-gray-200 p-4 dark:border-gray-700 md:grid-cols-2">
+										<!-- Cross Color -->
+										<div class="card">
 										<Label class="section-label mb-3">Cross Color</Label>
 										<div class="grid grid-cols-2 gap-2">
 											{#each STICKER_COLORS as color}
@@ -880,6 +881,7 @@
 								</div>
 							{/if}
 						</div>
+					</div>
 					</div>
 				</TabItem>
 			</Tabs>

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -64,13 +64,6 @@
 					workingSession.settings = JSON.parse(JSON.stringify(existingSession.settings));
 				}
 			}
-
-			// Prevent mobile keyboard from opening by blurring the auto-focused input
-			tick().then(() => {
-				if (document.activeElement instanceof HTMLElement) {
-					document.activeElement.blur();
-				}
-			});
 		}
 	});
 
@@ -145,14 +138,7 @@
 </script>
 
 {#if session && settings}
-	<Modal
-		bind:open
-		dismissable
-		size="lg"
-		outsideclose={false}
-		placement="top-center"
-		class="mt-8"
-	>
+	<Modal bind:open dismissable size="lg" outsideclose={false} placement="top-center" class="mt-8">
 		{#snippet header()}
 			<div class="flex items-center gap-1.5 pe-6">
 				{#if isEditingName}
@@ -164,7 +150,9 @@
 						class="w-64 rounded-md border-b-2 border-transparent bg-gray-50 px-1 py-0.5 text-xl font-medium text-gray-900 focus:border-primary-500 focus:outline-none dark:bg-gray-700 dark:text-white"
 					/>
 				{:else}
-					<h3 class="flex items-center gap-1.5 px-1 py-0.5 text-xl font-medium text-gray-900 dark:text-white">
+					<h3
+						class="flex items-center gap-1.5 px-1 py-0.5 text-xl font-medium text-gray-900 dark:text-white"
+					>
 						{session.name || 'Unnamed Session'}
 						<button
 							type="button"
@@ -177,7 +165,7 @@
 				{/if}
 			</div>
 		{/snippet}
-		<div class="flex flex-col gap-2 -mt-4">
+		<div class="-mt-4 flex flex-col gap-2">
 			<!-- General Settings Section -->
 
 			<Tabs

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -21,7 +21,14 @@
 	import { GROUP_IDS, GROUP_DEFINITIONS } from '$lib/types/group';
 	import { STICKER_COLORS, OPPOSITE_COLOR, type StickerColor } from '$lib/types/stickering';
 	import Update from '$lib/components/Modals/Buttons/Update.svelte';
-	import { CircleQuestionMark, Plus, RotateCcw, ChevronDown, ChevronRight, Settings } from '@lucide/svelte';
+	import {
+		CircleQuestionMark,
+		Plus,
+		RotateCcw,
+		ChevronDown,
+		ChevronRight,
+		Settings
+	} from '@lucide/svelte';
 	import TooltipButton from '$lib/components/Modals/TooltipButton.svelte';
 	import EdgeOrientationTooltipPreview from '$lib/components/Session/EdgeOrientationTooltipPreview.svelte';
 	import SessionIndividualCaseSelector from '$lib/components/Session/SessionIndividualCaseSelector.svelte';
@@ -273,7 +280,9 @@
 									</p>
 
 									<div class="ml-6 border-t border-gray-200 pt-3 dark:border-gray-700">
-										<div class="flex items-center gap-2 text-sm text-purple-600 dark:text-purple-400">
+										<div
+											class="flex items-center gap-2 text-sm text-purple-600 dark:text-purple-400"
+										>
 											<span class="font-medium">Requires Smart Cube</span>
 										</div>
 									</div>
@@ -351,11 +360,14 @@
 						</div>
 
 						<!-- Advanced Settings Well -->
-						<div class="-mt-2 rounded-xl border border-gray-200 bg-gray-50/50 shadow-sm dark:border-gray-700 dark:bg-gray-800/40">
+						<div
+							class="-mt-2 rounded-xl border border-gray-200 bg-gray-50/50 shadow-sm dark:border-gray-700 dark:bg-gray-800/40"
+						>
 							<button
 								type="button"
 								class="flex w-full items-center justify-start gap-2 p-4 text-sm font-medium text-blue-600 transition-colors hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-								onclick={() => (globalState.showAdvancedTraining = !globalState.showAdvancedTraining)}
+								onclick={() =>
+									(globalState.showAdvancedTraining = !globalState.showAdvancedTraining)}
 							>
 								{#if globalState.showAdvancedTraining}
 									<ChevronDown class="size-4" />
@@ -371,202 +383,215 @@
 									<div class="flex flex-col gap-2">
 										<Label class="text-sm font-semibold">Case Frequency</Label>
 
-								<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-									<!-- Smart Frequency Card -->
-									<!-- svelte-ignore a11y_click_events_have_key_events -->
-									<!-- svelte-ignore a11y_no_static_element_interactions -->
-									<div
-										class="selectable-card flex h-full flex-col {settings.frequencyMode === 'smart'
-											? 'selectable-card-active'
-											: 'selectable-card-inactive'}"
-										onclick={() => (settings.frequencyMode = 'smart')}
-									>
-										<div class="mb-2 flex items-center gap-2">
-											<RadioDot selected={settings.frequencyMode === 'smart'} />
-											<span class="font-medium text-gray-900 dark:text-white">Smart Frequency</span>
-										</div>
+										<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+											<!-- Smart Frequency Card -->
+											<!-- svelte-ignore a11y_click_events_have_key_events -->
+											<!-- svelte-ignore a11y_no_static_element_interactions -->
+											<div
+												class="selectable-card flex h-full flex-col {settings.frequencyMode ===
+												'smart'
+													? 'selectable-card-active'
+													: 'selectable-card-inactive'}"
+												onclick={() => (settings.frequencyMode = 'smart')}
+											>
+												<div class="mb-2 flex items-center gap-2">
+													<RadioDot selected={settings.frequencyMode === 'smart'} />
+													<span class="font-medium text-gray-900 dark:text-white"
+														>Smart Frequency</span
+													>
+												</div>
 
+												<div
+													class="ml-6 space-y-2 pt-2 {settings.frequencyMode !== 'smart'
+														? 'pointer-events-none opacity-50'
+														: ''}"
+												>
+													<Checkbox
+														bind:checked={settings.smartFrequencySolved}
+														class="text-sm"
+														onclick={(e) => e.stopPropagation()}>Prioritize Unsolved</Checkbox
+													>
+													<Checkbox
+														bind:checked={settings.smartFrequencyTime}
+														class="text-sm"
+														onclick={(e) => e.stopPropagation()}>Prioritize Slow</Checkbox
+													>
+												</div>
+											</div>
+
+											<!-- Recap Mode Card -->
+											<!-- svelte-ignore a11y_click_events_have_key_events -->
+											<!-- svelte-ignore a11y_no_static_element_interactions -->
+											<div
+												class="selectable-card flex h-full flex-col {settings.frequencyMode ===
+												'recap'
+													? 'selectable-card-active'
+													: 'selectable-card-inactive'}"
+												onclick={() => (settings.frequencyMode = 'recap')}
+											>
+												<div class="mb-2 flex items-center gap-2">
+													<RadioDot selected={settings.frequencyMode === 'recap'} />
+													<span class="font-medium text-gray-900 dark:text-white">Recap Mode</span>
+												</div>
+												<p class="ml-6 text-sm text-gray-500 dark:text-gray-400">
+													Cycles through all selected cases once, tracking your progress with a
+													progress bar.
+												</p>
+											</div>
+										</div>
+									</div>
+
+									<!-- Configuration & Assistance Grid -->
+									<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+										<!-- Training Setup Column -->
 										<div
-											class="ml-6 space-y-2 pt-2 {settings.frequencyMode !== 'smart'
-												? 'pointer-events-none opacity-50'
+											class="flex flex-col gap-2 {settings.trainMode === 'drill'
+												? 'sm:col-span-2'
 												: ''}"
 										>
-											<Checkbox
-												bind:checked={settings.smartFrequencySolved}
-												class="text-sm"
-												onclick={(e) => e.stopPropagation()}>Prioritize Unsolved</Checkbox
+											<Label class="text-sm font-semibold">Training Setup</Label>
+											<div
+												class="card h-full {settings.trainMode === 'drill'
+													? 'space-y-4 sm:grid sm:grid-cols-2 sm:gap-4 sm:space-y-0'
+													: 'space-y-4'}"
 											>
-											<Checkbox
-												bind:checked={settings.smartFrequencyTime}
-												class="text-sm"
-												onclick={(e) => e.stopPropagation()}>Prioritize Slow</Checkbox
-											>
-										</div>
-									</div>
+												<div>
+													<Label class="section-label mb-3">Cube Slots</Label>
+													<div class="space-y-2">
+														<Checkbox bind:checked={settings.trainSideSelection.left}
+															>Left Slots</Checkbox
+														>
+														<Checkbox bind:checked={settings.trainSideSelection.right}
+															>Right Slots</Checkbox
+														>
+													</div>
+												</div>
 
-									<!-- Recap Mode Card -->
-									<!-- svelte-ignore a11y_click_events_have_key_events -->
-									<!-- svelte-ignore a11y_no_static_element_interactions -->
-									<div
-										class="selectable-card flex h-full flex-col {settings.frequencyMode === 'recap'
-											? 'selectable-card-active'
-											: 'selectable-card-inactive'}"
-										onclick={() => (settings.frequencyMode = 'recap')}
-									>
-										<div class="mb-2 flex items-center gap-2">
-											<RadioDot selected={settings.frequencyMode === 'recap'} />
-											<span class="font-medium text-gray-900 dark:text-white">Recap Mode</span>
-										</div>
-										<p class="ml-6 text-sm text-gray-500 dark:text-gray-400">
-											Cycles through all selected cases once, tracking your progress with a progress
-											bar.
-										</p>
-									</div>
-								</div>
-							</div>
-
-							<!-- Configuration & Assistance Grid -->
-							<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-								<!-- Training Setup Column -->
-								<div
-									class="flex flex-col gap-2 {settings.trainMode === 'drill'
-										? 'sm:col-span-2'
-										: ''}"
-								>
-									<Label class="text-sm font-semibold">Training Setup</Label>
-									<div
-										class="card h-full {settings.trainMode === 'drill'
-											? 'space-y-4 sm:grid sm:grid-cols-2 sm:gap-4 sm:space-y-0'
-											: 'space-y-4'}"
-									>
-										<div>
-											<Label class="section-label mb-3">Cube Slots</Label>
-											<div class="space-y-2">
-												<Checkbox bind:checked={settings.trainSideSelection.left}
-													>Left Slots</Checkbox
+												<div
+													class="space-y-3 border-gray-200 dark:border-gray-700 {settings.trainMode ===
+													'drill'
+														? 'border-t pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-4'
+														: 'border-t pt-3'}"
 												>
-												<Checkbox bind:checked={settings.trainSideSelection.right}
-													>Right Slots</Checkbox
-												>
+													<div>
+														<Checkbox bind:checked={settings.trainAddAuf}>Add Random AUF</Checkbox>
+														<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
+															Adds a random U setup move to the beginning of the algorithm.
+														</p>
+													</div>
+													<Checkbox bind:checked={settings.trainShowTimer}>Show Timer</Checkbox>
+												</div>
 											</div>
 										</div>
 
-										<div
-											class="space-y-3 border-gray-200 dark:border-gray-700 {settings.trainMode ===
-											'drill'
-												? 'border-t pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-4'
-												: 'border-t pt-3'}"
-										>
-											<div>
-												<Checkbox bind:checked={settings.trainAddAuf}>Add Random AUF</Checkbox>
-												<p class="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
-													Adds a random U setup move to the beginning of the algorithm.
-												</p>
-											</div>
-											<Checkbox bind:checked={settings.trainShowTimer}>Show Timer</Checkbox>
-										</div>
-									</div>
-								</div>
-
-								<!-- Algorithm Hints Column -->
-								{#if settings.trainMode !== 'drill'}
-									<div class="flex flex-col gap-2">
-										<Label class="text-sm font-semibold">Algorithm Hints</Label>
-										<div class="card h-full space-y-4">
-											<div>
-												<div class="grid grid-cols-2 gap-2">
-													<!-- svelte-ignore a11y_click_events_have_key_events -->
-													<!-- svelte-ignore a11y_no_static_element_interactions -->
-													<div
-														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+										<!-- Algorithm Hints Column -->
+										{#if settings.trainMode !== 'drill'}
+											<div class="flex flex-col gap-2">
+												<Label class="text-sm font-semibold">Algorithm Hints</Label>
+												<div class="card h-full space-y-4">
+													<div>
+														<div class="grid grid-cols-2 gap-2">
+															<!-- svelte-ignore a11y_click_events_have_key_events -->
+															<!-- svelte-ignore a11y_no_static_element_interactions -->
+															<div
+																class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
 													{settings.trainHintAlgorithm === 'hidden'
-															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-														onclick={() => (settings.trainHintAlgorithm = 'hidden')}
-													>
-														<RadioDot selected={settings.trainHintAlgorithm === 'hidden'} />
-														<span class="text-sm text-gray-900 dark:text-white">Hidden</span>
-													</div>
-													<!-- svelte-ignore a11y_click_events_have_key_events -->
-													<!-- svelte-ignore a11y_no_static_element_interactions -->
-													<div
-														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+																	? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+																	: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+																onclick={() => (settings.trainHintAlgorithm = 'hidden')}
+															>
+																<RadioDot selected={settings.trainHintAlgorithm === 'hidden'} />
+																<span class="text-sm text-gray-900 dark:text-white">Hidden</span>
+															</div>
+															<!-- svelte-ignore a11y_click_events_have_key_events -->
+															<!-- svelte-ignore a11y_no_static_element_interactions -->
+															<div
+																class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
 													{settings.trainHintAlgorithm === 'step'
-															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-														onclick={() => (settings.trainHintAlgorithm = 'step')}
-													>
-														<RadioDot selected={settings.trainHintAlgorithm === 'step'} />
-														<span class="text-sm text-gray-900 dark:text-white">Step-by-step</span>
-													</div>
-													<!-- svelte-ignore a11y_click_events_have_key_events -->
-													<!-- svelte-ignore a11y_no_static_element_interactions -->
-													<div
-														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+																	? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+																	: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+																onclick={() => (settings.trainHintAlgorithm = 'step')}
+															>
+																<RadioDot selected={settings.trainHintAlgorithm === 'step'} />
+																<span class="text-sm text-gray-900 dark:text-white"
+																	>Step-by-step</span
+																>
+															</div>
+															<!-- svelte-ignore a11y_click_events_have_key_events -->
+															<!-- svelte-ignore a11y_no_static_element_interactions -->
+															<div
+																class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
 													{settings.trainHintAlgorithm === 'allAtOnce'
-															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-														onclick={() => (settings.trainHintAlgorithm = 'allAtOnce')}
-													>
-														<RadioDot selected={settings.trainHintAlgorithm === 'allAtOnce'} />
-														<span class="text-sm text-gray-900 dark:text-white">All at once</span>
-													</div>
-													<!-- svelte-ignore a11y_click_events_have_key_events -->
-													<!-- svelte-ignore a11y_no_static_element_interactions -->
-													<div
-														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+																	? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+																	: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+																onclick={() => (settings.trainHintAlgorithm = 'allAtOnce')}
+															>
+																<RadioDot selected={settings.trainHintAlgorithm === 'allAtOnce'} />
+																<span class="text-sm text-gray-900 dark:text-white"
+																	>All at once</span
+																>
+															</div>
+															<!-- svelte-ignore a11y_click_events_have_key_events -->
+															<!-- svelte-ignore a11y_no_static_element_interactions -->
+															<div
+																class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
 													{settings.trainHintAlgorithm === 'always'
-															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-														onclick={() => (settings.trainHintAlgorithm = 'always')}
-													>
-														<RadioDot selected={settings.trainHintAlgorithm === 'always'} />
-														<span class="text-sm text-gray-900 dark:text-white">Always show</span>
+																	? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+																	: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+																onclick={() => (settings.trainHintAlgorithm = 'always')}
+															>
+																<RadioDot selected={settings.trainHintAlgorithm === 'always'} />
+																<span class="text-sm text-gray-900 dark:text-white"
+																	>Always show</span
+																>
+															</div>
+														</div>
 													</div>
-												</div>
-											</div>
 
-											<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
-												<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
-												<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-													This setting only applies when training with a connected smart cube.
-												</p>
-												<div class="grid grid-cols-2 gap-2">
-													<!-- svelte-ignore a11y_click_events_have_key_events -->
-													<!-- svelte-ignore a11y_no_static_element_interactions -->
-													<div
-														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+													<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
+														<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
+														<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+															This setting only applies when training with a connected smart cube.
+														</p>
+														<div class="grid grid-cols-2 gap-2">
+															<!-- svelte-ignore a11y_click_events_have_key_events -->
+															<!-- svelte-ignore a11y_no_static_element_interactions -->
+															<div
+																class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
 													{settings.smartHintBehavior === 'auto'
-															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-														onclick={() => (settings.smartHintBehavior = 'auto')}
-													>
-														<RadioDot selected={settings.smartHintBehavior === 'auto'} />
-														<span class="text-sm text-gray-900 dark:text-white">Auto-track</span>
-													</div>
-													<!-- svelte-ignore a11y_click_events_have_key_events -->
-													<!-- svelte-ignore a11y_no_static_element_interactions -->
-													<div
-														class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+																	? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+																	: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+																onclick={() => (settings.smartHintBehavior = 'auto')}
+															>
+																<RadioDot selected={settings.smartHintBehavior === 'auto'} />
+																<span class="text-sm text-gray-900 dark:text-white">Auto-track</span
+																>
+															</div>
+															<!-- svelte-ignore a11y_click_events_have_key_events -->
+															<!-- svelte-ignore a11y_no_static_element_interactions -->
+															<div
+																class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
 													{settings.smartHintBehavior === 'manual'
-															? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-															: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-														onclick={() => (settings.smartHintBehavior = 'manual')}
-													>
-														<RadioDot selected={settings.smartHintBehavior === 'manual'} />
-														<span class="text-sm text-gray-900 dark:text-white">Manual clicks</span>
+																	? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+																	: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+																onclick={() => (settings.smartHintBehavior = 'manual')}
+															>
+																<RadioDot selected={settings.smartHintBehavior === 'manual'} />
+																<span class="text-sm text-gray-900 dark:text-white"
+																	>Manual clicks</span
+																>
+															</div>
+														</div>
 													</div>
 												</div>
 											</div>
-										</div>
+										{/if}
 									</div>
-								{/if}
-							</div>
+								</div>
+							{/if}
 						</div>
-					{/if}
 					</div>
-				</div>
-			</TabItem>
+				</TabItem>
 
 				<TabItem key="appearance" title="Appearance">
 					<div class="mt-4 flex flex-col gap-4">
@@ -602,7 +627,7 @@
 												triggeredBy="#btn-f2l-stickering-help"
 												trigger="click"
 												class="p-2"
-												placement="left"
+												placement="top"
 											>
 												<twisty-player
 													style="width: 120px; height: 120px;"
@@ -645,7 +670,7 @@
 												triggeredBy="#btn-fully-stickered-help"
 												trigger="click"
 												class="p-2"
-												placement="left"
+												placement="top"
 											>
 												<twisty-player
 													style="width: 120px; height: 120px;"
@@ -688,7 +713,7 @@
 												triggeredBy="#btn-floating-stickers-help"
 												trigger="click"
 												class="p-2"
-												placement="left"
+												placement="top"
 											>
 												<twisty-player
 													style="width: 120px; height: 120px;"
@@ -719,7 +744,7 @@
 												triggeredBy="#btn-back-view-help"
 												trigger="click"
 												class="p-2"
-												placement="left"
+												placement="top"
 											>
 												<twisty-player
 													style="width: 120px; height: 120px;"
@@ -742,11 +767,14 @@
 							</div>
 
 							<!-- Advanced Settings Well -->
-							<div class="-mt-2 rounded-xl border border-gray-200 bg-gray-50/50 shadow-sm dark:border-gray-700 dark:bg-gray-800/40">
+							<div
+								class="-mt-2 rounded-xl border border-gray-200 bg-gray-50/50 shadow-sm dark:border-gray-700 dark:bg-gray-800/40"
+							>
 								<button
 									type="button"
 									class="flex w-full items-center justify-start gap-2 p-4 text-sm font-medium text-blue-600 transition-colors hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-									onclick={() => (globalState.showAdvancedAppearance = !globalState.showAdvancedAppearance)}
+									onclick={() =>
+										(globalState.showAdvancedAppearance = !globalState.showAdvancedAppearance)}
 								>
 									{#if globalState.showAdvancedAppearance}
 										<ChevronDown class="size-4" />
@@ -757,131 +785,134 @@
 								</button>
 
 								{#if globalState.showAdvancedAppearance}
-									<div class="grid grid-cols-1 gap-4 border-t border-gray-200 p-4 dark:border-gray-700 md:grid-cols-2">
+									<div
+										class="grid grid-cols-1 gap-4 border-t border-gray-200 p-4 md:grid-cols-2 dark:border-gray-700"
+									>
 										<!-- Cross Color -->
 										<div class="card">
-										<Label class="section-label mb-3">Cross Color</Label>
-										<div class="grid grid-cols-2 gap-2">
-											{#each STICKER_COLORS as color}
-												<Checkbox bind:group={settings.crossColor} value={color}>
-													{color.charAt(0).toUpperCase() + color.slice(1)}
-												</Checkbox>
-											{/each}
+											<Label class="section-label mb-3">Cross Color</Label>
+											<div class="grid grid-cols-2 gap-2">
+												{#each STICKER_COLORS as color}
+													<Checkbox bind:group={settings.crossColor} value={color}>
+														{color.charAt(0).toUpperCase() + color.slice(1)}
+													</Checkbox>
+												{/each}
+											</div>
 										</div>
-									</div>
 
-									<!-- Front Color -->
-									<div class="card">
-										<Label class="section-label mb-3">Front Color</Label>
-										<div class="grid grid-cols-2 gap-2">
-											{#each STICKER_COLORS as color}
-												{@const isDisabled =
-													settings.crossColor.length > 1 ||
-													(settings.crossColor.length === 1 &&
-														!settings.crossColor.every(
-															(c: any) => c !== color && OPPOSITE_COLOR[c as StickerColor] !== color
-														))}
-												<Checkbox
-													bind:group={settings.frontColor}
-													value={color}
-													disabled={isDisabled}
-												>
-													{color.charAt(0).toUpperCase() + color.slice(1)}
-												</Checkbox>
-											{/each}
+										<!-- Front Color -->
+										<div class="card">
+											<Label class="section-label mb-3">Front Color</Label>
+											<div class="grid grid-cols-2 gap-2">
+												{#each STICKER_COLORS as color}
+													{@const isDisabled =
+														settings.crossColor.length > 1 ||
+														(settings.crossColor.length === 1 &&
+															!settings.crossColor.every(
+																(c: any) =>
+																	c !== color && OPPOSITE_COLOR[c as StickerColor] !== color
+															))}
+													<Checkbox
+														bind:group={settings.frontColor}
+														value={color}
+														disabled={isDisabled}
+													>
+														{color.charAt(0).toUpperCase() + color.slice(1)}
+													</Checkbox>
+												{/each}
+											</div>
+											{#if settings.crossColor.length > 1}
+												<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+													Randomized when multiple cross colors selected.
+												</p>
+											{/if}
 										</div>
-										{#if settings.crossColor.length > 1}
-											<p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-												Randomized when multiple cross colors selected.
-											</p>
-										{/if}
-									</div>
 
-									<!-- Edge Orientation -->
-									<div class="card">
-										<Label class="mb-3 text-sm font-semibold">Edge Orientation</Label>
-										<div class="space-y-4">
-											<div class="flex items-center gap-2">
-												<Checkbox bind:checked={settings.trainLearnEO}
-													>Learn Edge Orientation</Checkbox
-												>
-												<Button
-													id="btn-edge-orientation-help"
-													class="bg-transparent p-1 hover:bg-transparent focus:bg-transparent dark:bg-transparent dark:hover:bg-transparent dark:focus:bg-transparent"
-													type="button"
-													onclick={(e: MouseEvent) => e.stopPropagation()}
-												>
-													<CircleQuestionMark class="text-primary-600" />
-												</Button>
-												<Tooltip
-													triggeredBy="#btn-edge-orientation-help"
-													trigger="click"
-													class="p-3"
-													placement="left"
-												>
-													<div class="space-y-3">
-														<p class="max-w-xs text-xs text-gray-600 dark:text-gray-300">
-															When enabled, highlight F2L edges by orientation
-														</p>
-														<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-															<EdgeOrientationTooltipPreview
-																caseId={1}
-																description="Oriented edge"
-																class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/80"
+										<!-- Edge Orientation -->
+										<div class="card">
+											<Label class="mb-3 text-sm font-semibold">Edge Orientation</Label>
+											<div class="space-y-4">
+												<div class="flex items-center gap-2">
+													<Checkbox bind:checked={settings.trainLearnEO}
+														>Learn Edge Orientation</Checkbox
+													>
+													<Button
+														id="btn-edge-orientation-help"
+														class="bg-transparent p-1 hover:bg-transparent focus:bg-transparent dark:bg-transparent dark:hover:bg-transparent dark:focus:bg-transparent"
+														type="button"
+														onclick={(e: MouseEvent) => e.stopPropagation()}
+													>
+														<CircleQuestionMark class="text-primary-600" />
+													</Button>
+													<Tooltip
+														triggeredBy="#btn-edge-orientation-help"
+														trigger="click"
+														class="p-2"
+														placement="bottom"
+													>
+														<div class="w-min space-y-3">
+															<p class="text-xs text-gray-600 dark:text-gray-300">
+																When enabled, highlight F2L edges by orientation
+															</p>
+															<div class="grid w-max grid-cols-1 gap-3 sm:grid-cols-2">
+																<EdgeOrientationTooltipPreview
+																	caseId={1}
+																	description="Oriented edge"
+																	class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/80"
+																/>
+																<EdgeOrientationTooltipPreview
+																	caseId={11}
+																	description="Unoriented edge"
+																	class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/80"
+																/>
+															</div>
+														</div>
+													</Tooltip>
+												</div>
+												{#if settings.trainLearnEO}
+													<div
+														class="grid grid-cols-2 gap-4 border-t border-gray-200 pt-3 dark:border-gray-700"
+													>
+														<div>
+															<Label class="mb-2 text-xs">Oriented Color</Label>
+															<input
+																type="color"
+																bind:value={globalState.eoOrientedColor}
+																class="h-8 w-full cursor-pointer rounded border border-gray-300 p-0"
 															/>
-															<EdgeOrientationTooltipPreview
-																caseId={11}
-																description="Unoriented edge"
-																class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/80"
+														</div>
+														<div>
+															<Label class="mb-2 text-xs">Unoriented Color</Label>
+															<input
+																type="color"
+																bind:value={globalState.eoUnorientedColor}
+																class="h-8 w-full cursor-pointer rounded border border-gray-300 p-0"
 															/>
 														</div>
 													</div>
-												</Tooltip>
-											</div>
-											{#if settings.trainLearnEO}
-												<div
-													class="grid grid-cols-2 gap-4 border-t border-gray-200 pt-3 dark:border-gray-700"
-												>
-													<div>
-														<Label class="mb-2 text-xs">Oriented Color</Label>
-														<input
-															type="color"
-															bind:value={globalState.eoOrientedColor}
-															class="h-8 w-full cursor-pointer rounded border border-gray-300 p-0"
-														/>
-													</div>
-													<div>
-														<Label class="mb-2 text-xs">Unoriented Color</Label>
-														<input
-															type="color"
-															bind:value={globalState.eoUnorientedColor}
-															class="h-8 w-full cursor-pointer rounded border border-gray-300 p-0"
-														/>
-													</div>
-												</div>
-												{#if hasChangedEOColors}
-													<div class="mt-4 flex justify-end">
-														<Button
-															size="xs"
-															color="alternative"
-															onclick={() => {
-																globalState.eoOrientedColor = DEFAULT_EO_ORIENTED_COLOR;
-																globalState.eoUnorientedColor = DEFAULT_EO_UNORIENTED_COLOR;
-															}}
-															class="gap-1.5"
-														>
-															<RotateCcw size={14} />
-															Reset to Default
-														</Button>
-													</div>
+													{#if hasChangedEOColors}
+														<div class="mt-4 flex justify-end">
+															<Button
+																size="xs"
+																color="alternative"
+																onclick={() => {
+																	globalState.eoOrientedColor = DEFAULT_EO_ORIENTED_COLOR;
+																	globalState.eoUnorientedColor = DEFAULT_EO_UNORIENTED_COLOR;
+																}}
+																class="gap-1.5"
+															>
+																<RotateCcw size={14} />
+																Reset to Default
+															</Button>
+														</div>
+													{/if}
 												{/if}
-											{/if}
+											</div>
 										</div>
 									</div>
-								</div>
-							{/if}
+								{/if}
+							</div>
 						</div>
-					</div>
 					</div>
 				</TabItem>
 			</Tabs>

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import {
 		Input,
 		Label,
@@ -62,6 +63,13 @@
 					workingSession.settings = JSON.parse(JSON.stringify(existingSession.settings));
 				}
 			}
+
+			// Prevent mobile keyboard from opening by blurring the auto-focused input
+			tick().then(() => {
+				if (document.activeElement instanceof HTMLElement) {
+					document.activeElement.blur();
+				}
+			});
 		}
 	});
 

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -548,7 +548,7 @@
 														</div>
 													</div>
 
-													{#if settings.trainHintAlgorithm !== 'hidden' && settings.trainHintAlgorithm !== 'always'}
+													{#if settings.trainHintAlgorithm !== 'hidden'}
 														<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
 															<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
 															<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -548,41 +548,43 @@
 														</div>
 													</div>
 
-													<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
-														<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
-														<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-															This setting only applies when training with a connected smart cube.
-														</p>
-														<div class="grid grid-cols-2 gap-2">
-															<!-- svelte-ignore a11y_click_events_have_key_events -->
-															<!-- svelte-ignore a11y_no_static_element_interactions -->
-															<div
-																class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
-													{settings.smartHintBehavior === 'auto'
-																	? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-																	: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-																onclick={() => (settings.smartHintBehavior = 'auto')}
-															>
-																<RadioDot selected={settings.smartHintBehavior === 'auto'} />
-																<span class="text-sm text-gray-900 dark:text-white">Auto-track</span
+													{#if settings.trainHintAlgorithm !== 'hidden' && settings.trainHintAlgorithm !== 'always'}
+														<div class="border-t border-gray-200 pt-3 dark:border-gray-700">
+															<Label class="section-label mb-3">Smart Cube Hint Tracking</Label>
+															<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+																This setting only applies when training with a connected smart cube.
+															</p>
+															<div class="grid grid-cols-2 gap-2">
+																<!-- svelte-ignore a11y_click_events_have_key_events -->
+																<!-- svelte-ignore a11y_no_static_element_interactions -->
+																<div
+																	class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+														{settings.smartHintBehavior === 'auto'
+																		? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+																		: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+																	onclick={() => (settings.smartHintBehavior = 'auto')}
 																>
-															</div>
-															<!-- svelte-ignore a11y_click_events_have_key_events -->
-															<!-- svelte-ignore a11y_no_static_element_interactions -->
-															<div
-																class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
-													{settings.smartHintBehavior === 'manual'
-																	? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
-																	: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
-																onclick={() => (settings.smartHintBehavior = 'manual')}
-															>
-																<RadioDot selected={settings.smartHintBehavior === 'manual'} />
-																<span class="text-sm text-gray-900 dark:text-white"
-																	>Manual clicks</span
+																	<RadioDot selected={settings.smartHintBehavior === 'auto'} />
+																	<span class="text-sm text-gray-900 dark:text-white">Auto-track</span
+																	>
+																</div>
+																<!-- svelte-ignore a11y_click_events_have_key_events -->
+																<!-- svelte-ignore a11y_no_static_element_interactions -->
+																<div
+																	class="flex cursor-pointer items-center gap-2 rounded-lg border p-3 transition-colors
+														{settings.smartHintBehavior === 'manual'
+																		? 'border-blue-600 bg-blue-50 dark:bg-blue-900/20'
+																		: 'border-gray-300 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500'}"
+																	onclick={() => (settings.smartHintBehavior = 'manual')}
 																>
+																	<RadioDot selected={settings.smartHintBehavior === 'manual'} />
+																	<span class="text-sm text-gray-900 dark:text-white"
+																		>Manual clicks</span
+																	>
+																</div>
 															</div>
 														</div>
-													</div>
+													{/if}
 												</div>
 											</div>
 										{/if}

--- a/src/lib/components/Session/SessionSettingsModal.svelte
+++ b/src/lib/components/Session/SessionSettingsModal.svelte
@@ -565,7 +565,8 @@
 																	onclick={() => (settings.smartHintBehavior = 'auto')}
 																>
 																	<RadioDot selected={settings.smartHintBehavior === 'auto'} />
-																	<span class="text-sm text-gray-900 dark:text-white">Auto-track</span
+																	<span class="text-sm text-gray-900 dark:text-white"
+																		>Auto-track</span
 																	>
 																</div>
 																<!-- svelte-ignore a11y_click_events_have_key_events -->

--- a/src/lib/components/TrainView/DrillTimer.svelte
+++ b/src/lib/components/TrainView/DrillTimer.svelte
@@ -167,7 +167,7 @@
 	});
 </script>
 
-<div class="mt-0 mb-2 flex w-full flex-col items-center md:mt-0 md:mb-4">
+<div class="flex w-full flex-col items-center">
 	<div
 		class="relative min-w-60 rounded border bg-transparent p-4 shadow-sm transition-colors select-none"
 		class:border-gray-300={phase !== 'stopped'}

--- a/src/lib/components/TrainView/HintButton.svelte
+++ b/src/lib/components/TrainView/HintButton.svelte
@@ -50,13 +50,9 @@
 	let showPlaceholder = $derived(visible && hintCounter === -1 && hintMode !== 'always');
 	let showAlgorithm = $derived(visible && displayedAlg !== '');
 
-
-
 	// Tailwind classes - uses display-box utility from app.css and adds specific overrides
 	const className =
 		'display-box cursor-pointer text-xl md:text-2xl hover:bg-gray-50 dark:hover:bg-gray-700 focus:ring-2 focus:ring-primary-600 focus:outline-none';
-
-
 
 	const editButtonClass =
 		'hover:bg-opacity-90 flex-shrink-0 rounded-full p-2 text-primary-500 transition-all duration-200';
@@ -90,7 +86,7 @@
 					<span class="text-xl text-theme-text md:text-2xl">Press to show hint</span>
 				{:else if showAlgorithm}
 					<span
-						class="whitespace-pre-wrap font-mono text-xl font-semibold tracking-wide md:text-3xl"
+						class="font-mono text-xl font-semibold tracking-wide whitespace-pre-wrap md:text-3xl"
 					>
 						{displayedAlg}
 					</span>

--- a/src/lib/components/TrainView/HintButton.svelte
+++ b/src/lib/components/TrainView/HintButton.svelte
@@ -73,7 +73,7 @@
 </script>
 
 <!-- Container holds both the alg viewer element (used by TwistyAlgViewer) and the hint button UI -->
-<div class="my-2 flex w-full flex-col items-center md:my-4">
+<div class="flex w-full flex-col items-center">
 	<div class="relative flex max-w-full items-center justify-center gap-2">
 		<div
 			bind:this={algViewerContainer}

--- a/src/lib/components/TrainView/HintButton.svelte
+++ b/src/lib/components/TrainView/HintButton.svelte
@@ -50,20 +50,13 @@
 	let showPlaceholder = $derived(visible && hintCounter === -1 && hintMode !== 'always');
 	let showAlgorithm = $derived(visible && displayedAlg !== '');
 
-	// Parse the algorithm into individual moves for consistent display
-	let algMoves = $derived.by(() => {
-		if (!showAlgorithm) return [];
-		return displayedAlg.split(' ').filter((move) => move.trim() !== '');
-	});
+
 
 	// Tailwind classes - uses display-box utility from app.css and adds specific overrides
 	const className =
 		'display-box cursor-pointer text-xl md:text-2xl hover:bg-gray-50 dark:hover:bg-gray-700 focus:ring-2 focus:ring-primary-600 focus:outline-none';
 
-	const algContainerClass =
-		'inline-flex flex-wrap items-center justify-center gap-1 font-mono text-lg font-semibold md:text-3xl';
 
-	const chipClass = 'rounded bg-gray-100 px-2 py-1 font-mono font-semibold text-theme-text';
 
 	const editButtonClass =
 		'hover:bg-opacity-90 flex-shrink-0 rounded-full p-2 text-primary-500 transition-all duration-200';
@@ -96,11 +89,11 @@
 				{#if showPlaceholder}
 					<span class="text-xl text-theme-text md:text-2xl">Press to show hint</span>
 				{:else if showAlgorithm}
-					<div class={algContainerClass}>
-						{#each algMoves as move}
-							<span class={chipClass}>{move}</span>
-						{/each}
-					</div>
+					<span
+						class="whitespace-pre-wrap font-mono text-xl font-semibold tracking-wide md:text-3xl"
+					>
+						{displayedAlg}
+					</span>
 				{/if}
 			</div>
 		{/if}

--- a/src/lib/components/TrainView/HintButtonSmart.svelte
+++ b/src/lib/components/TrainView/HintButtonSmart.svelte
@@ -70,7 +70,9 @@
 		'text-center',
 		'text-xl md:text-2xl',
 		'shadow-sm',
-		'transition-colors'
+		'transition-colors',
+		'relative',
+		'overflow-hidden'
 	].join(' ');
 
 	const className = hintBase;
@@ -170,6 +172,22 @@
 			{:else}
 				<span class="text-xl text-theme-text md:text-2xl">No algorithm available</span>
 			{/if}
+
+			{#if hasUndoMoves}
+				<div
+					class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 bg-amber-50/95 p-2 backdrop-blur-[2px] dark:bg-amber-950/95"
+				>
+					<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+						<Undo2 class="size-4 md:size-5" strokeWidth={2.5} />
+						<span class="text-xs font-semibold tracking-wide uppercase md:text-sm">Undo Required</span>
+					</div>
+					<div class="flex flex-wrap items-center justify-center gap-1">
+						{#each undoMoves as move}
+							<span class={undoChipClass}>{move}</span>
+						{/each}
+					</div>
+				</div>
+			{/if}
 		</div>
 
 		{#if showEditButton}
@@ -190,22 +208,6 @@
 			</button>
 		{/if}
 	</div>
-
-	{#if hasUndoMoves}
-		<div
-			class="mt-3 flex flex-col items-center gap-2 rounded-lg border-2 border-amber-400 bg-amber-50 p-3 dark:border-amber-600 dark:bg-amber-950/30"
-		>
-			<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
-				<Undo2 class="size-5" strokeWidth={2.5} />
-				<span class="text-sm font-semibold tracking-wide uppercase">Undo Required</span>
-			</div>
-			<div class="flex flex-wrap items-center justify-center gap-1">
-				{#each undoMoves as move}
-					<span class={undoChipClass}>{move}</span>
-				{/each}
-			</div>
-		</div>
-	{/if}
 
 	<!-- <div class="mt-2 flex flex-col items-center gap-1">
 		<span class="text-xs tracking-wide text-gray-500 uppercase dark:text-gray-400"

--- a/src/lib/components/TrainView/HintButtonSmart.svelte
+++ b/src/lib/components/TrainView/HintButtonSmart.svelte
@@ -179,7 +179,9 @@
 				>
 					<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
 						<Undo2 class="size-4 md:size-5" strokeWidth={2.5} />
-						<span class="text-xs font-semibold tracking-wide uppercase md:text-sm">Undo Required</span>
+						<span class="text-xs font-semibold tracking-wide uppercase md:text-sm"
+							>Undo Required</span
+						>
 					</div>
 					<div class="flex flex-wrap items-center justify-center gap-1">
 						{#each undoMoves as move}

--- a/src/lib/components/TrainView/HintButtonSmart.svelte
+++ b/src/lib/components/TrainView/HintButtonSmart.svelte
@@ -144,7 +144,7 @@
 </script>
 
 <!-- Container holds the hint button UI -->
-<div class="my-2 flex w-full flex-col items-center md:my-4">
+<div class="flex w-full flex-col items-center">
 	<div class="relative flex max-w-full items-center justify-center gap-2">
 		<div class={`${className} ${getContainerFeedbackClass(validationFeedback)}`}>
 			{#if totalMoves > 0}

--- a/src/lib/components/TrainView/SmartTimer.svelte
+++ b/src/lib/components/TrainView/SmartTimer.svelte
@@ -95,7 +95,7 @@
 	});
 </script>
 
-<div class="mt-0 mb-2 flex w-full flex-col items-center md:mt-0 md:mb-4">
+<div class="flex w-full flex-col items-center">
 	<div
 		class="relative min-w-60 rounded border border-gray-300 bg-transparent p-5 text-center font-mono text-4xl font-bold shadow-sm transition-colors select-none md:text-5xl"
 		aria-label="Timer"

--- a/src/lib/components/TrainView/Timer.svelte
+++ b/src/lib/components/TrainView/Timer.svelte
@@ -121,7 +121,7 @@
 	});
 </script>
 
-<div class="mt-0 mb-2 flex w-full flex-col items-center md:mt-0 md:mb-4">
+<div class="flex w-full flex-col items-center">
 	<button
 		type="button"
 		onpointerdown={handlePointerDown}

--- a/src/lib/components/TrainView/TrainClassic.svelte
+++ b/src/lib/components/TrainView/TrainClassic.svelte
@@ -71,6 +71,15 @@
 	}
 
 	async function onNext() {
+		const wasTimerRunning = timerRef?.getIsRunning();
+
+		if (wasTimerRunning) {
+			timerRef?.stopTimer();
+			timerRef?.resetTimer();
+			// User skipped an active case, reset the time to 0 instead of showing previous time
+			trainState.lastDisplayedTime = 0;
+		}
+
 		if (currentTrainCase) {
 			const { groupId, caseId } = currentTrainCase;
 

--- a/src/lib/components/TrainView/TrainClassic.svelte
+++ b/src/lib/components/TrainView/TrainClassic.svelte
@@ -307,6 +307,8 @@
 	{/if}
 </div>
 
+<div class="my-2 flex w-full flex-col items-center gap-2 md:my-4 md:gap-4">
+{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
 <HintButton
 	{alg}
 	bind:algViewerContainer
@@ -320,9 +322,11 @@
 		editAlgRef?.openModal();
 	}}
 />
+{/if}
 {#if sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer}
 	<Timer bind:this={timerRef} onStop={handleTimerStop} initialTime={displayTime} />
 {/if}
+</div>
 <RecapProgress />
 
 <div class="flex flex-row items-center justify-center gap-2">

--- a/src/lib/components/TrainView/TrainClassic.svelte
+++ b/src/lib/components/TrainView/TrainClassic.svelte
@@ -317,24 +317,24 @@
 </div>
 
 <div class="my-2 flex w-full flex-col items-center gap-2 md:my-4 md:gap-4">
-{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
-<HintButton
-	{alg}
-	bind:algViewerContainer
-	showAlgViewer={hintManager.showAlgViewer}
-	visible={hintManager.showHintButton}
-	hintCounter={hintManager.counter}
-	hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
-		DEFAULT_SETTINGS.trainHintAlgorithm}
-	onclick={showHintAlg}
-	onEditAlg={() => {
-		editAlgRef?.openModal();
-	}}
-/>
-{/if}
-{#if sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer}
-	<Timer bind:this={timerRef} onStop={handleTimerStop} initialTime={displayTime} />
-{/if}
+	<div class="w-full" style:display={(sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden' ? 'block' : 'none'}>
+		<HintButton
+			{alg}
+			bind:algViewerContainer
+			showAlgViewer={hintManager.showAlgViewer}
+			visible={hintManager.showHintButton}
+			hintCounter={hintManager.counter}
+			hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
+				DEFAULT_SETTINGS.trainHintAlgorithm}
+			onclick={showHintAlg}
+			onEditAlg={() => {
+				editAlgRef?.openModal();
+			}}
+		/>
+	</div>
+	{#if sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer}
+		<Timer bind:this={timerRef} onStop={handleTimerStop} initialTime={displayTime} />
+	{/if}
 </div>
 <RecapProgress />
 

--- a/src/lib/components/TrainView/TrainClassic.svelte
+++ b/src/lib/components/TrainView/TrainClassic.svelte
@@ -317,7 +317,13 @@
 </div>
 
 <div class="my-2 flex w-full flex-col items-center gap-2 md:my-4 md:gap-4">
-	<div class="w-full" style:display={(sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden' ? 'block' : 'none'}>
+	<div
+		class="w-full"
+		style:display={(sessionState.activeSession?.settings.trainHintAlgorithm ??
+			DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'
+			? 'block'
+			: 'none'}
+	>
 		<HintButton
 			{alg}
 			bind:algViewerContainer

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -661,9 +661,7 @@
 <div class="flex flex-row items-center justify-center gap-2">
 	<TrainStateSelect
 		onremove={async () => {
-			advanceToNextTrainCase();
-			await tick();
-			phase = 'scrambling';
+			onNext();
 		}}
 	/>
 	<span class="text-sm text-gray-500 dark:text-gray-400"

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -268,7 +268,8 @@
 
 	function validateMoveProgress() {
 		// Disable algorithm validation and auto-rotation if the hint is hidden
-		if ((sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) === 'hidden') {
+		// (but ONLY during the solving phases, we still need to validate the scramble!)
+		if (phase !== 'scrambling' && (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) === 'hidden') {
 			return;
 		}
 

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -18,7 +18,16 @@
 	import HintButtonSmart from './HintButtonSmart.svelte';
 	import DrillTimer from './DrillTimer.svelte';
 	import { globalState } from '$lib/globalState.svelte';
-	import { Pointer, Check, RotateCcw, Bluetooth, EllipsisVertical, Undo2, ArrowLeft, ArrowRight } from '@lucide/svelte';
+	import {
+		Pointer,
+		Check,
+		RotateCcw,
+		Bluetooth,
+		EllipsisVertical,
+		Undo2,
+		ArrowLeft,
+		ArrowRight
+	} from '@lucide/svelte';
 	import Details from './Details.svelte';
 	import TrainStateSelect from './TrainStateSelect.svelte';
 	import RecapProgress from './RecapProgress.svelte';
@@ -40,10 +49,12 @@
 		getSliceImplicitRotation,
 		getSliceFirstMoves,
 		inverseMove,
-		isUMove
+		isUMove,
+		invertRotationsWithoutReversing
 	} from '$lib/utils/moveValidator';
 	import { fade } from 'svelte/transition';
 	import { simplifyAlg } from '$lib/utils/simplifyAlg';
+	import getRotationAlg from '$lib/rotation';
 
 	type Phase = 'scrambling' | 'countdown' | 'solving' | 'executing' | 'transitioning';
 	let phase = $state<Phase>('scrambling');
@@ -98,6 +109,15 @@
 			: undefined
 	);
 
+	// Calculate the rotation needed to map from hardware standard (White Up/Green Front) to the user's target orientation
+	let hardwareOffset = $derived.by(() => {
+		if (!currentTrainCase) return '';
+		const setupRot = getRotationAlg(currentTrainCase.crossColor, currentTrainCase.frontColor);
+		// To map from Hardware (OLD) to Target (NEW) via applyRotationToMove (which processes left-to-right),
+		// we must invert each individual rotation in the setup sequence while keeping the original order.
+		return invertRotationsWithoutReversing(setupRot);
+	});
+
 	$effect(() => {
 		if (currentTrainCase) {
 			const { groupId, caseId, auf, side, scramble: scrambleSelection } = currentTrainCase;
@@ -146,8 +166,11 @@
 	});
 
 	function handleSmartCubeMove(move: string) {
-		const m = move.trim();
-		if (!m) return;
+		const rawM = move.trim();
+		if (!rawM) return;
+
+		// Convert hardware move to user's intended base move based on their preferred colors
+		const m = applyRotationToMove(rawM, hardwareOffset);
 
 		if (phase === 'transitioning' || phase === 'countdown') return;
 
@@ -163,7 +186,10 @@
 			moveBuffer = [...moveBuffer, m];
 
 			let lookAheadIndex = currentMoveIndex;
-			while (lookAheadIndex < algMovesParsed.length && isRotationMove(algMovesParsed[lookAheadIndex])) {
+			while (
+				lookAheadIndex < algMovesParsed.length &&
+				isRotationMove(algMovesParsed[lookAheadIndex])
+			) {
 				lookAheadIndex++;
 			}
 			const nextNonRotationMove = algMovesParsed[lookAheadIndex];
@@ -180,7 +206,6 @@
 			}
 
 			validateMoveProgress();
-
 		} catch (e) {
 			console.warn('Failed to apply move:', m, e);
 		}
@@ -211,7 +236,9 @@
 			if (incomingInAlgFrame === expectedUndo) {
 				undoMoves = undoMoves.slice(1);
 				validationFeedback = 'correct';
-				setTimeout(() => { validationFeedback = 'neutral'; }, 300);
+				setTimeout(() => {
+					validationFeedback = 'neutral';
+				}, 300);
 			} else {
 				const inverseRaw = inverseMove(rawMove);
 				const undoInAlgFrame = applyRotationToMove(inverseRaw, inverseRot);
@@ -222,7 +249,9 @@
 		moveBuffer = [];
 		if (undoMoves.length === 0) {
 			validationFeedback = 'correct';
-			setTimeout(() => { validationFeedback = 'neutral'; }, 500);
+			setTimeout(() => {
+				validationFeedback = 'neutral';
+			}, 500);
 		}
 	}
 
@@ -240,7 +269,10 @@
 		if (twistyPlayerRef && isRotationMove(algMovesParsed[currentMoveIndex])) {
 			const rotationsToApply: string[] = [];
 			let rotationIndex = currentMoveIndex;
-			while (rotationIndex < algMovesParsed.length && isRotationMove(algMovesParsed[rotationIndex])) {
+			while (
+				rotationIndex < algMovesParsed.length &&
+				isRotationMove(algMovesParsed[rotationIndex])
+			) {
 				rotationsToApply.push(algMovesParsed[rotationIndex]);
 				rotationIndex++;
 			}
@@ -249,7 +281,9 @@
 				twistyPlayerRef.addMove(rotation, '');
 			}
 
-			const allRotations = cumulativeRotation ? [cumulativeRotation, ...rotationsToApply] : rotationsToApply;
+			const allRotations = cumulativeRotation
+				? [cumulativeRotation, ...rotationsToApply]
+				: rotationsToApply;
 			cumulativeRotation = combineRotations(allRotations);
 			caseHasRotation = true;
 			currentMoveIndex = rotationIndex;
@@ -274,7 +308,9 @@
 					currentMoveIndex++;
 					moveBuffer = [];
 					validationFeedback = 'correct';
-					setTimeout(() => { validationFeedback = 'neutral'; }, 500);
+					setTimeout(() => {
+						validationFeedback = 'neutral';
+					}, 500);
 					checkPhaseCompletion();
 					return;
 				}
@@ -304,14 +340,20 @@
 
 			currentMoveIndex += consumedCount;
 			moveBuffer = [];
-			setTimeout(() => { validationFeedback = 'neutral'; }, 500);
+			setTimeout(() => {
+				validationFeedback = 'neutral';
+			}, 500);
 			checkPhaseCompletion();
 		} else if (normalized.length >= 1) {
 			const expectedMove = expectedMoves[0];
 			const isExpectedDoubleMove = expectedMove && expectedMove.includes('2');
 			const expectedBaseFace = expectedMove ? expectedMove.replace(/['2]/g, '') : '';
-			const couldBeDoubleMove = isExpectedDoubleMove && moveBuffer.length === 1 && normalized.length === 1 && normalized[0].replace(/['2]/g, '') === expectedBaseFace;
-			
+			const couldBeDoubleMove =
+				isExpectedDoubleMove &&
+				moveBuffer.length === 1 &&
+				normalized.length === 1 &&
+				normalized[0].replace(/['2]/g, '') === expectedBaseFace;
+
 			let couldBeSliceMove = false;
 			if (isSliceMove(expectedMove) && moveBuffer.length === 1 && normalized.length === 1) {
 				const validFirstMoves = getSliceFirstMoves(expectedMove);
@@ -329,7 +371,7 @@
 		if (currentMoveIndex >= algMovesParsed.length) {
 			if (phase === 'scrambling') {
 				phase = 'countdown';
-				
+
 				// Clear the accumulated scramble moves from TwistyPlayer
 				twistyPlayerRef?.reset();
 
@@ -342,13 +384,13 @@
 				movesAdded = '';
 				caseHasRotation = false;
 				showRotationWarning = false;
-				
+
 				// Ensure UI has updated
 				await tick();
-				
+
 				// Wait for countdown duration
 				await new Promise((resolve) => setTimeout(resolve, countdownDuration * 1000));
-				
+
 				// Ensure phase hasn't changed (e.g. skipped)
 				if (phase === 'countdown') {
 					phase = 'solving';
@@ -370,7 +412,9 @@
 
 	let connectButtonLabel = $derived.by(() => {
 		if (bluetoothState.isConnected) {
-			const saved = bluetoothState.deviceId ? savedCubesState.getCube(bluetoothState.deviceId) : null;
+			const saved = bluetoothState.deviceId
+				? savedCubesState.getCube(bluetoothState.deviceId)
+				: null;
 			return saved?.customName || bluetoothState.deviceName || 'Connected';
 		}
 		if (latestSavedCube) return latestSavedCube.customName;
@@ -388,7 +432,7 @@
 			await connectNewCube();
 		}
 	}
-	
+
 	let completedMoves = $derived(algMovesParsed.slice(0, currentMoveIndex));
 	let currentMoves = $derived(
 		currentMoveIndex < algMovesParsed.length ? [algMovesParsed[currentMoveIndex]] : []
@@ -409,7 +453,8 @@
 
 	const getContainerFeedbackClass = (feedback: 'correct' | 'incorrect' | 'neutral') => {
 		if (feedback === 'correct') return 'border-green-500 bg-green-50 dark:bg-green-950/20';
-		if (feedback === 'incorrect') return 'border-red-500 bg-red-50 dark:bg-red-950/20 animate-shake';
+		if (feedback === 'incorrect')
+			return 'border-red-500 bg-red-50 dark:bg-red-950/20 animate-shake';
 		return 'border-transparent';
 	};
 
@@ -435,12 +480,16 @@
 		<Button class="btn-icon-transparent shrink-0" type="button" onclick={onPrevious}>
 			<ArrowLeft class="size-8 text-primary-600 md:size-12" />
 		</Button>
-		
+
 		<div class="flex flex-col items-center">
 			<!-- Scramble guide (maintains layout space when hidden) -->
-			<div class="flex flex-col items-center transition-opacity duration-200 {phase !== 'scrambling' ? 'opacity-0 pointer-events-none' : 'opacity-100'}">
+			<div
+				class="flex flex-col items-center transition-opacity duration-200 {phase !== 'scrambling'
+					? 'pointer-events-none opacity-0'
+					: 'opacity-100'}"
+			>
 				<div
-					class="relative overflow-hidden flex min-w-48 flex-wrap items-center justify-center gap-1 rounded-lg border-2 p-3 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
+					class="relative flex min-w-48 flex-wrap items-center justify-center gap-1 overflow-hidden rounded-lg border-2 p-3 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
 						validationFeedback
 					)}"
 				>
@@ -459,7 +508,10 @@
 							<span class={futureChipVisible}>{move}</span>
 						{/each}
 					{:else}
-						{#each displayScramble.replace(/[()]/g, '').split(' ').filter((m) => m.trim() !== '') as move}
+						{#each displayScramble
+							.replace(/[()]/g, '')
+							.split(' ')
+							.filter((m) => m.trim() !== '') as move}
 							<span class={completedChipClass}>{move}</span>
 						{/each}
 					{/if}
@@ -470,7 +522,9 @@
 						>
 							<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
 								<Undo2 class="size-4 md:size-5" strokeWidth={2.5} />
-								<span class="text-xs font-semibold tracking-wide uppercase md:text-sm">Undo Required</span>
+								<span class="text-xs font-semibold tracking-wide uppercase md:text-sm"
+									>Undo Required</span
+								>
 							</div>
 							<div class="flex flex-wrap items-center justify-center gap-1">
 								{#each undoMoves as move}
@@ -508,7 +562,9 @@
 				class="absolute inset-0 z-50 flex flex-col items-center justify-center gap-2 rounded-xl bg-yellow-500/20 backdrop-blur-[1px]"
 			>
 				<RotateCcw size={60} class="text-yellow-600 drop-shadow-lg dark:text-yellow-400" />
-				<div class="text-center text-3xl font-bold text-yellow-600 drop-shadow-sm dark:text-yellow-400">
+				<div
+					class="text-center text-3xl font-bold text-yellow-600 drop-shadow-sm dark:text-yellow-400"
+				>
 					Rotate to<br />Home Position
 				</div>
 			</div>
@@ -556,9 +612,11 @@
 				side={currentTrainCase.side}
 				crossColor={currentTrainCase.crossColor}
 				frontColor={currentTrainCase.frontColor}
-				enableEOColoring={sessionState.activeSession?.settings.trainLearnEO ?? DEFAULT_SETTINGS.trainLearnEO}
+				enableEOColoring={sessionState.activeSession?.settings.trainLearnEO ??
+					DEFAULT_SETTINGS.trainLearnEO}
 				scrambleSelection={currentTrainCase.scramble}
-				stickering={sessionState.activeSession?.settings.trainHintStickering ?? DEFAULT_SETTINGS.trainHintStickering}
+				stickering={sessionState.activeSession?.settings.trainHintStickering ??
+					DEFAULT_SETTINGS.trainHintStickering}
 				backView={sessionState.activeSession?.settings.backView || 'none'}
 				backViewEnabled={sessionState.activeSession?.settings.backViewEnabled || false}
 				experimentalDragInput="auto"
@@ -568,7 +626,9 @@
 				tempoScale={5}
 				showAlg={false}
 				disableAutoScramble={phase === 'scrambling'}
-				hidePlayer={phase === 'countdown' || (phase === 'scrambling' && !(sessionState.activeSession?.settings.scrambleShowCube ?? true))}
+				hidePlayer={phase === 'countdown' ||
+					(phase === 'scrambling' &&
+						!(sessionState.activeSession?.settings.scrambleShowCube ?? true))}
 				onF2LSolved={() => {
 					if (phase === 'solving' || phase === 'executing') {
 						const executionTime = drillTimerRef?.stopExecution() ?? 0;
@@ -616,8 +676,6 @@
 		{/if}
 	</div>
 
-
-
 	<div
 		class="mt-2"
 		class:hidden={!(
@@ -631,7 +689,9 @@
 		alg={displayAlg}
 		movesAdded={phase === 'scrambling' || phase === 'countdown' ? '' : movesAdded}
 		currentMoveIndex={phase === 'scrambling' || phase === 'countdown' ? 0 : currentMoveIndex}
-		validationFeedback={phase === 'scrambling' || phase === 'countdown' ? 'neutral' : validationFeedback}
+		validationFeedback={phase === 'scrambling' || phase === 'countdown'
+			? 'neutral'
+			: validationFeedback}
 		undoMoves={phase === 'scrambling' || phase === 'countdown' ? [] : undoMoves}
 		editDisabled={currentMoveIndex > 0 || movesAdded.trim() !== ''}
 		hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -36,7 +36,8 @@
 		isSliceMove,
 		getSliceImplicitRotation,
 		getSliceFirstMoves,
-		inverseMove
+		inverseMove,
+		isUMove
 	} from '$lib/utils/moveValidator';
 	import { fade } from 'svelte/transition';
 	import { simplifyAlg } from '$lib/utils/simplifyAlg';
@@ -50,7 +51,13 @@
 	let displayScramble = $state('');
 	let displayAlg = $state('');
 
-	let algMovesParsed = $state<string[]>([]);
+	let algMovesParsed = $derived.by(() => {
+		const algToParse = phase === 'scrambling' ? displayScramble : displayAlg;
+		if (!algToParse) return [];
+		const cleanAlg = algToParse.replace(/[()]/g, '');
+		return cleanAlg.split(' ').filter((m) => m.trim() !== '');
+	});
+
 	let currentMoveIndex = $state(0);
 	let moveBuffer = $state<string[]>([]);
 	let validationFeedback = $state<'correct' | 'incorrect' | 'neutral'>('neutral');
@@ -117,29 +124,18 @@
 		}
 	});
 
+	// Reset state when case changes
 	$effect(() => {
-		// When phase changes to scrambling or displayScramble changes
-		if (phase === 'scrambling' && displayScramble) {
+		if (currentTrainCase) {
 			untrack(() => {
-				const cleanAlg = displayScramble.replace(/[()]/g, '');
-				algMovesParsed = cleanAlg.split(' ').filter((m) => m.trim() !== '');
 				currentMoveIndex = 0;
 				moveBuffer = [];
 				validationFeedback = 'neutral';
 				cumulativeRotation = '';
 				undoMoves = [];
 				movesAdded = '';
-			});
-		} else if (phase !== 'scrambling') {
-			untrack(() => {
-				const cleanAlg = displayAlg.replace(/[()]/g, '');
-				algMovesParsed = cleanAlg.split(' ').filter((m) => m.trim() !== '');
-				currentMoveIndex = 0;
-				moveBuffer = [];
-				validationFeedback = 'neutral';
-				cumulativeRotation = '';
-				undoMoves = [];
-				movesAdded = '';
+				caseHasRotation = false;
+				showRotationWarning = false;
 			});
 		}
 	});
@@ -149,6 +145,10 @@
 		if (!m) return;
 
 		if (phase === 'transitioning' || phase === 'countdown') return;
+
+		if (phase === 'solving' && !isUMove(m)) {
+			phase = 'executing';
+		}
 
 		if (!twistyPlayerRef) return;
 		if (showRotationWarning) showRotationWarning = false;
@@ -324,6 +324,19 @@
 			if (phase === 'scrambling') {
 				phase = 'countdown';
 				
+				// Clear the accumulated scramble moves from TwistyPlayer
+				twistyPlayerRef?.reset();
+
+				// Reset move tracking state for the solve phase
+				currentMoveIndex = 0;
+				moveBuffer = [];
+				validationFeedback = 'neutral';
+				cumulativeRotation = '';
+				undoMoves = [];
+				movesAdded = '';
+				caseHasRotation = false;
+				showRotationWarning = false;
+				
 				// Ensure UI has updated
 				await tick();
 				
@@ -391,10 +404,8 @@
 		return 'border-transparent';
 	};
 
-	async function onNext() {
-		// Just for testing step 2 - advance immediately
+	function onNext() {
 		advanceToNextTrainCase();
-		await tick();
 		phase = 'scrambling';
 		twistyPlayerRef?.reset();
 		movesAdded = '';
@@ -563,14 +574,17 @@
 
 	<HintButtonSmart
 		alg={displayAlg}
-		movesAdded={phase === 'scrambling' ? '' : movesAdded}
-		currentMoveIndex={phase === 'scrambling' ? 0 : currentMoveIndex}
-		validationFeedback={phase === 'scrambling' ? 'neutral' : validationFeedback}
-		undoMoves={phase === 'scrambling' ? [] : undoMoves}
-		editDisabled={true}
-		hintMode={'always'}
-		hasMadeFirstMove={phase !== 'scrambling'}
-		onEditAlg={() => {}}
+		movesAdded={phase === 'scrambling' || phase === 'countdown' ? '' : movesAdded}
+		currentMoveIndex={phase === 'scrambling' || phase === 'countdown' ? 0 : currentMoveIndex}
+		validationFeedback={phase === 'scrambling' || phase === 'countdown' ? 'neutral' : validationFeedback}
+		undoMoves={phase === 'scrambling' || phase === 'countdown' ? [] : undoMoves}
+		editDisabled={currentMoveIndex > 0 || movesAdded.trim() !== ''}
+		hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
+			DEFAULT_SETTINGS.trainHintAlgorithm}
+		hasMadeFirstMove={phase === 'executing' || phase === 'transitioning'}
+		onEditAlg={() => {
+			editAlgRef?.openModal();
+		}}
 	/>
 
 	<RecapProgress />

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -711,31 +711,34 @@
 		{/if}
 	</div>
 
-	<div
-		class="mt-2"
-		class:hidden={!(
-			sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer
-		)}
-	>
-		<DrillTimer bind:this={drillTimerRef} />
-	</div>
+	<div class="my-2 flex w-full flex-col items-center gap-2 md:my-4 md:gap-4">
+		<div
+			class:hidden={!(
+				sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer
+			)}
+		>
+			<DrillTimer bind:this={drillTimerRef} />
+		</div>
 
-	<HintButtonSmart
-		alg={displayAlg}
-		movesAdded={phase === 'scrambling' || phase === 'countdown' ? '' : movesAdded}
-		currentMoveIndex={phase === 'scrambling' || phase === 'countdown' ? 0 : currentMoveIndex}
-		validationFeedback={phase === 'scrambling' || phase === 'countdown'
-			? 'neutral'
-			: validationFeedback}
-		undoMoves={phase === 'scrambling' || phase === 'countdown' ? [] : undoMoves}
-		editDisabled={currentMoveIndex > 0 || movesAdded.trim() !== ''}
-		hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
-			DEFAULT_SETTINGS.trainHintAlgorithm}
-		hasMadeFirstMove={phase === 'executing' || phase === 'transitioning'}
-		onEditAlg={() => {
-			editAlgRef?.openModal();
-		}}
-	/>
+		{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
+		<HintButtonSmart
+			alg={displayAlg}
+			movesAdded={phase === 'scrambling' || phase === 'countdown' ? '' : movesAdded}
+			currentMoveIndex={phase === 'scrambling' || phase === 'countdown' ? 0 : currentMoveIndex}
+			validationFeedback={phase === 'scrambling' || phase === 'countdown'
+				? 'neutral'
+				: validationFeedback}
+			undoMoves={phase === 'scrambling' || phase === 'countdown' ? [] : undoMoves}
+			editDisabled={currentMoveIndex > 0 || movesAdded.trim() !== ''}
+			hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
+				DEFAULT_SETTINGS.trainHintAlgorithm}
+			hasMadeFirstMove={phase === 'executing' || phase === 'transitioning'}
+			onEditAlg={() => {
+				editAlgRef?.openModal();
+			}}
+		/>
+		{/if}
+	</div>
 
 	<RecapProgress />
 {:else}

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -293,9 +293,12 @@
 	function validateMoveProgress() {
 		// Disable algorithm validation and auto-rotation if the hint is hidden or manual
 		// (but ONLY during the solving phases, we still need to validate the scramble!)
-		const hintAlgorithm = sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm;
-		const hintBehavior = sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
-		
+		const hintAlgorithm =
+			sessionState.activeSession?.settings.trainHintAlgorithm ??
+			DEFAULT_SETTINGS.trainHintAlgorithm;
+		const hintBehavior =
+			sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
+
 		if (phase !== 'scrambling' && (hintAlgorithm === 'hidden' || hintBehavior === 'manual')) {
 			return;
 		}

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -267,6 +267,11 @@
 	}
 
 	function validateMoveProgress() {
+		// Disable algorithm validation and auto-rotation if the hint is hidden
+		if ((sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) === 'hidden') {
+			return;
+		}
+
 		if (undoMoves.length > 0) {
 			validateUndoProgress();
 			return;

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -28,7 +28,8 @@
 		EllipsisVertical,
 		Undo2,
 		ArrowLeft,
-		ArrowRight
+		ArrowRight,
+		Info
 	} from '@lucide/svelte';
 	import Details from './Details.svelte';
 	import TrainStateSelect from './TrainStateSelect.svelte';
@@ -553,7 +554,7 @@
 					: 'opacity-100'}"
 			>
 				<div
-					class="relative flex min-w-48 flex-wrap items-center justify-center gap-1 overflow-hidden rounded-lg border-2 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
+					class="relative flex min-w-48 flex-wrap items-center justify-center gap-1 rounded-lg border-2 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
 						validationFeedback
 					)}"
 				>
@@ -582,7 +583,7 @@
 
 					{#if undoMoves.length > 0 && phase === 'scrambling'}
 						<div
-							class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 bg-amber-50/95 p-2 backdrop-blur-[2px] dark:bg-amber-950/95"
+							class="absolute top-1/2 left-1/2 z-10 flex min-h-[calc(100%+4px)] w-[calc(100%+4px)] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center gap-1 rounded-lg border-2 border-amber-500 bg-amber-50/95 p-0 backdrop-blur-[2px] dark:border-amber-600 dark:bg-amber-950/95"
 						>
 							<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
 								<Undo2 class="size-4 md:size-5" strokeWidth={2.5} />
@@ -598,6 +599,14 @@
 						</div>
 					{/if}
 				</div>
+				{#if undoMoves.length >= 2 && phase === 'scrambling'}
+					<div
+						class="mt-4 flex items-center gap-1.5 rounded-full bg-purple-600 px-3 py-1 text-md font-semibold text-white shadow-md transition-opacity"
+					>
+						<Info class="size-4" />
+						<span>Hold cube as shown</span>
+					</div>
+				{/if}
 			</div>
 		</div>
 

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -9,11 +9,13 @@
 	import { tick, untrack, onDestroy } from 'svelte';
 	import { casesState, getCaseAlg, getCaseScramble } from '$lib/casesState.svelte';
 	import { sessionState, DEFAULT_SETTINGS } from '$lib/sessionState.svelte';
+	import { statisticsState } from '$lib/statisticsState.svelte';
 	import Settings from '$lib/components/Modals/Settings.svelte';
 	import EditAlg from '$lib/components/Modals/EditAlgModal.svelte';
 	import { casesStatic } from '$lib/casesStatic';
 	import { concatinateAuf } from '$lib/utils/addAuf';
 	import HintButtonSmart from './HintButtonSmart.svelte';
+	import DrillTimer from './DrillTimer.svelte';
 	import { globalState } from '$lib/globalState.svelte';
 	import { Pointer, Check, RotateCcw, Bluetooth, EllipsisVertical, Undo2 } from '@lucide/svelte';
 	import Details from './Details.svelte';
@@ -47,6 +49,7 @@
 
 	let editAlgRef = $state<EditAlg>();
 	let twistyPlayerRef = $state<any>();
+	let drillTimerRef = $state<DrillTimer>();
 
 	let displayScramble = $state('');
 	let displayAlg = $state('');
@@ -136,6 +139,7 @@
 				movesAdded = '';
 				caseHasRotation = false;
 				showRotationWarning = false;
+				drillTimerRef?.reset();
 			});
 		}
 	});
@@ -148,6 +152,7 @@
 
 		if (phase === 'solving' && !isUMove(m)) {
 			phase = 'executing';
+			drillTimerRef?.endRecognition();
 		}
 
 		if (!twistyPlayerRef) return;
@@ -346,6 +351,9 @@
 				// Ensure phase hasn't changed (e.g. skipped)
 				if (phase === 'countdown') {
 					phase = 'solving';
+					await tick();
+					drillTimerRef?.reset();
+					drillTimerRef?.startRecognition();
 				}
 			}
 		}
@@ -405,6 +413,7 @@
 	};
 
 	function onNext() {
+		drillTimerRef?.reset();
 		advanceToNextTrainCase();
 		phase = 'scrambling';
 		twistyPlayerRef?.reset();
@@ -545,6 +554,32 @@
 				hidePlayer={phase === 'countdown' || (phase === 'scrambling' && !(sessionState.activeSession?.settings.scrambleShowCube ?? true))}
 				onF2LSolved={() => {
 					if (phase === 'solving' || phase === 'executing') {
+						const executionTime = drillTimerRef?.stopExecution() ?? 0;
+						const recognitionTime = drillTimerRef?.getRecognitionTime() ?? 0;
+
+						if (currentTrainCase) {
+							const totalTime = recognitionTime + executionTime;
+							currentTrainCase.time = totalTime;
+							currentTrainCase.solveId = crypto.randomUUID();
+							trainState.lastDisplayedTime = totalTime;
+
+							statisticsState.addSolve({
+								id: currentTrainCase.solveId,
+								groupId: currentTrainCase.groupId,
+								caseId: currentTrainCase.caseId,
+								time: totalTime,
+								timestamp: Date.now(),
+								auf: currentTrainCase.auf,
+								side: currentTrainCase.side,
+								scrambleSelection: currentTrainCase.scramble,
+								sessionId: sessionState.activeSessionId || undefined,
+								recognitionTime,
+								executionTime,
+								trainMode: 'smartScramble'
+							});
+							currentTrainCase.solved = true;
+						}
+
 						phase = 'transitioning';
 						setTimeout(() => {
 							onNext();
@@ -569,6 +604,17 @@
 			<span class="text-md rounded-full bg-purple-600 px-3 py-1 font-semibold text-white shadow-md">
 				Hold Green Front, White Up
 			</span>
+		</div>
+	{/if}
+
+	{#if phase !== 'scrambling' && phase !== 'countdown'}
+		<div
+			class="mt-2"
+			class:hidden={!(
+				sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer
+			)}
+		>
+			<DrillTimer bind:this={drillTimerRef} />
 		</div>
 	{/if}
 

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -1,7 +1,578 @@
 <script lang="ts">
+	import { Button, ButtonGroup, P, Spinner } from 'flowbite-svelte';
+	import TwistyPlayer from '../TwistyPlayer.svelte';
+	import {
+		advanceToNextTrainCase,
+		getNumberOfSelectedCases,
+		trainState
+	} from '$lib/trainCaseQueue.svelte';
+	import { tick, untrack, onDestroy } from 'svelte';
+	import { casesState, getCaseAlg, getCaseScramble } from '$lib/casesState.svelte';
+	import { sessionState, DEFAULT_SETTINGS } from '$lib/sessionState.svelte';
+	import Settings from '$lib/components/Modals/Settings.svelte';
+	import EditAlg from '$lib/components/Modals/EditAlgModal.svelte';
+	import { casesStatic } from '$lib/casesStatic';
+	import { concatinateAuf } from '$lib/utils/addAuf';
+	import HintButtonSmart from './HintButtonSmart.svelte';
+	import { globalState } from '$lib/globalState.svelte';
+	import { Pointer, Check, RotateCcw, Bluetooth, EllipsisVertical, Undo2 } from '@lucide/svelte';
+	import Details from './Details.svelte';
+	import TrainStateSelect from './TrainStateSelect.svelte';
+	import RecapProgress from './RecapProgress.svelte';
+	import { bluetoothState } from '$lib/bluetooth/store.svelte';
+	import { savedCubesState } from '$lib/bluetooth/savedCubes.svelte';
+	import { connectNewCube, connectSavedCube } from '$lib/bluetooth/actions';
+	import BluetoothModal from '$lib/components/Modals/BluetoothModal.svelte';
+	import {
+		isRotationMove,
+		matchesMoveSequence,
+		normalizeMoves,
+		applyRotationToMove,
+		combineRotations,
+		inverseRotation,
+		isWideMove,
+		wideToSingleLayerMove,
+		getWideImplicitRotation,
+		isSliceMove,
+		getSliceImplicitRotation,
+		getSliceFirstMoves,
+		inverseMove
+	} from '$lib/utils/moveValidator';
+	import { fade } from 'svelte/transition';
+	import { simplifyAlg } from '$lib/utils/simplifyAlg';
+
+	type Phase = 'scrambling' | 'countdown' | 'solving' | 'executing' | 'transitioning';
+	let phase = $state<Phase>('scrambling');
+
+	let editAlgRef = $state<EditAlg>();
+	let twistyPlayerRef = $state<any>();
+
+	let displayScramble = $state('');
+	let displayAlg = $state('');
+
+	let algMovesParsed = $state<string[]>([]);
+	let currentMoveIndex = $state(0);
+	let moveBuffer = $state<string[]>([]);
+	let validationFeedback = $state<'correct' | 'incorrect' | 'neutral'>('neutral');
+	let cumulativeRotation = $state('');
+	let undoMoves = $state<string[]>([]);
+	let showRotationWarning = $state(false);
+	let movesAdded = $state('');
+	let caseHasRotation = $state(false);
+
+	const SUBSCRIBER_ID = 'train-classic-scramble';
+	const SUBSCRIBER_PRIORITY = 50;
+
+	// Only subscribe when we have a train case
+	$effect(() => {
+		const hasTrainCase = !!trainState.current;
+		if (hasTrainCase) {
+			bluetoothState.subscribeToMoves(SUBSCRIBER_ID, handleSmartCubeMove, SUBSCRIBER_PRIORITY);
+			return () => {
+				bluetoothState.unsubscribeFromMoves(SUBSCRIBER_ID);
+			};
+		}
+	});
+
+	let currentTrainCase = $derived(trainState.current);
+	let currentAlgorithmSelection = $derived(
+		currentTrainCase
+			? casesState[currentTrainCase.groupId][currentTrainCase.caseId].algorithmSelection
+			: undefined
+	);
+
+	$effect(() => {
+		if (currentTrainCase) {
+			const { groupId, caseId, auf, side, scramble: scrambleSelection } = currentTrainCase;
+			const staticData = casesStatic[groupId]?.[caseId];
+
+			if (staticData) {
+				const caseState = casesState[groupId]?.[caseId];
+				const algWithoutAUF = getCaseAlg(
+					staticData,
+					currentAlgorithmSelection ?? caseState?.algorithmSelection ?? { left: 0, right: 0 },
+					caseState?.customAlgorithm ?? { left: '', right: '' },
+					side
+				);
+				const scrambleWithoutAUF = getCaseScramble(staticData, side, scrambleSelection);
+
+				if (algWithoutAUF && scrambleWithoutAUF && auf !== undefined) {
+					const [newScramble, newAlg] = concatinateAuf(scrambleWithoutAUF, algWithoutAUF, auf);
+					displayScramble = simplifyAlg(newScramble);
+					displayAlg = simplifyAlg(newAlg);
+				} else {
+					displayScramble = '';
+					displayAlg = '';
+				}
+			}
+		} else {
+			displayScramble = '';
+			displayAlg = '';
+		}
+	});
+
+	$effect(() => {
+		// When phase changes to scrambling or displayScramble changes
+		if (phase === 'scrambling' && displayScramble) {
+			untrack(() => {
+				const cleanAlg = displayScramble.replace(/[()]/g, '');
+				algMovesParsed = cleanAlg.split(' ').filter((m) => m.trim() !== '');
+				currentMoveIndex = 0;
+				moveBuffer = [];
+				validationFeedback = 'neutral';
+				cumulativeRotation = '';
+				undoMoves = [];
+				movesAdded = '';
+			});
+		} else if (phase !== 'scrambling') {
+			untrack(() => {
+				const cleanAlg = displayAlg.replace(/[()]/g, '');
+				algMovesParsed = cleanAlg.split(' ').filter((m) => m.trim() !== '');
+				currentMoveIndex = 0;
+				moveBuffer = [];
+				validationFeedback = 'neutral';
+				cumulativeRotation = '';
+				undoMoves = [];
+				movesAdded = '';
+			});
+		}
+	});
+
+	function handleSmartCubeMove(move: string) {
+		const m = move.trim();
+		if (!m) return;
+
+		if (phase === 'transitioning' || phase === 'countdown') return;
+
+		if (!twistyPlayerRef) return;
+		if (showRotationWarning) showRotationWarning = false;
+
+		try {
+			moveBuffer = [...moveBuffer, m];
+
+			let lookAheadIndex = currentMoveIndex;
+			while (lookAheadIndex < algMovesParsed.length && isRotationMove(algMovesParsed[lookAheadIndex])) {
+				lookAheadIndex++;
+			}
+			const nextNonRotationMove = algMovesParsed[lookAheadIndex];
+			const isNextWideMove = nextNonRotationMove && isWideMove(nextNonRotationMove);
+
+			const inverseRot = inverseRotation(cumulativeRotation);
+			const transformedMove = applyRotationToMove(m, inverseRot);
+
+			if (isNextWideMove) {
+				twistyPlayerRef.addMove('', m);
+			} else {
+				twistyPlayerRef.addMove(transformedMove, m);
+				movesAdded += (movesAdded ? ' ' : '') + transformedMove;
+			}
+
+			validateMoveProgress();
+
+		} catch (e) {
+			console.warn('Failed to apply move:', m, e);
+		}
+	}
+
+	function addUndoMovesFromBuffer() {
+		const inverseRot = inverseRotation(cumulativeRotation);
+		const newUndoMoves: string[] = [];
+		for (let i = moveBuffer.length - 1; i >= 0; i--) {
+			const rawMove = moveBuffer[i];
+			const inverseRaw = inverseMove(rawMove);
+			const undoInAlgFrame = applyRotationToMove(inverseRaw, inverseRot);
+			newUndoMoves.push(undoInAlgFrame);
+		}
+		undoMoves = [...undoMoves, ...newUndoMoves];
+		moveBuffer = [];
+	}
+
+	function validateUndoProgress() {
+		if (moveBuffer.length === 0) return;
+		const inverseRot = inverseRotation(cumulativeRotation);
+
+		for (const rawMove of moveBuffer) {
+			if (undoMoves.length === 0) break;
+			const incomingInAlgFrame = applyRotationToMove(rawMove, inverseRot);
+			const expectedUndo = undoMoves[0];
+
+			if (incomingInAlgFrame === expectedUndo) {
+				undoMoves = undoMoves.slice(1);
+				validationFeedback = 'correct';
+				setTimeout(() => { validationFeedback = 'neutral'; }, 300);
+			} else {
+				const inverseRaw = inverseMove(rawMove);
+				const undoInAlgFrame = applyRotationToMove(inverseRaw, inverseRot);
+				undoMoves = [undoInAlgFrame, ...undoMoves];
+				validationFeedback = 'incorrect';
+			}
+		}
+		moveBuffer = [];
+		if (undoMoves.length === 0) {
+			validationFeedback = 'correct';
+			setTimeout(() => { validationFeedback = 'neutral'; }, 500);
+		}
+	}
+
+	function validateMoveProgress() {
+		if (undoMoves.length > 0) {
+			validateUndoProgress();
+			return;
+		}
+
+		if (currentMoveIndex >= algMovesParsed.length) {
+			validationFeedback = 'neutral';
+			return;
+		}
+
+		if (twistyPlayerRef && isRotationMove(algMovesParsed[currentMoveIndex])) {
+			const rotationsToApply: string[] = [];
+			let rotationIndex = currentMoveIndex;
+			while (rotationIndex < algMovesParsed.length && isRotationMove(algMovesParsed[rotationIndex])) {
+				rotationsToApply.push(algMovesParsed[rotationIndex]);
+				rotationIndex++;
+			}
+
+			for (const rotation of rotationsToApply) {
+				twistyPlayerRef.addMove(rotation, '');
+			}
+
+			const allRotations = cumulativeRotation ? [cumulativeRotation, ...rotationsToApply] : rotationsToApply;
+			cumulativeRotation = combineRotations(allRotations);
+			caseHasRotation = true;
+			currentMoveIndex = rotationIndex;
+		}
+
+		if (currentMoveIndex < algMovesParsed.length && isWideMove(algMovesParsed[currentMoveIndex])) {
+			const wideMove = algMovesParsed[currentMoveIndex];
+			const singleLayerMove = wideToSingleLayerMove(wideMove);
+			const implicitRotation = getWideImplicitRotation(wideMove);
+
+			if (singleLayerMove) {
+				const inverseRot = inverseRotation(cumulativeRotation);
+				const transformedBuffer = moveBuffer.map((move) => applyRotationToMove(move, inverseRot));
+				const normalized = normalizeMoves(transformedBuffer);
+				const { match, consumedCount } = matchesMoveSequence(normalized, [singleLayerMove]);
+
+				if (match && consumedCount > 0) {
+					twistyPlayerRef.addMove(wideMove, '');
+					caseHasRotation = true;
+					const rotationsToUpdate = [implicitRotation, cumulativeRotation].filter((r) => r !== '');
+					cumulativeRotation = combineRotations(rotationsToUpdate);
+					currentMoveIndex++;
+					moveBuffer = [];
+					validationFeedback = 'correct';
+					setTimeout(() => { validationFeedback = 'neutral'; }, 500);
+					checkPhaseCompletion();
+					return;
+				}
+			}
+		}
+
+		const expectedMoves = algMovesParsed.slice(currentMoveIndex, currentMoveIndex + 5);
+		const inverseRot = inverseRotation(cumulativeRotation);
+		const transformedBuffer = moveBuffer.map((move) => applyRotationToMove(move, inverseRot));
+		const normalized = normalizeMoves(transformedBuffer);
+		const { match, consumedCount } = matchesMoveSequence(normalized, expectedMoves);
+
+		if (match && consumedCount > 0) {
+			validationFeedback = 'correct';
+			const matchedMoves = algMovesParsed.slice(currentMoveIndex, currentMoveIndex + consumedCount);
+			for (const matchedMove of matchedMoves) {
+				if (isSliceMove(matchedMove)) {
+					const implicitRot = getSliceImplicitRotation(matchedMove);
+					if (implicitRot) {
+						twistyPlayerRef.addMove(implicitRot, '');
+						caseHasRotation = true;
+						const rotationsToUpdate = [implicitRot, cumulativeRotation].filter((r) => r !== '');
+						cumulativeRotation = combineRotations(rotationsToUpdate);
+					}
+				}
+			}
+
+			currentMoveIndex += consumedCount;
+			moveBuffer = [];
+			setTimeout(() => { validationFeedback = 'neutral'; }, 500);
+			checkPhaseCompletion();
+		} else if (normalized.length >= 1) {
+			const expectedMove = expectedMoves[0];
+			const isExpectedDoubleMove = expectedMove && expectedMove.includes('2');
+			const expectedBaseFace = expectedMove ? expectedMove.replace(/['2]/g, '') : '';
+			const couldBeDoubleMove = isExpectedDoubleMove && moveBuffer.length === 1 && normalized.length === 1 && normalized[0].replace(/['2]/g, '') === expectedBaseFace;
+			
+			let couldBeSliceMove = false;
+			if (isSliceMove(expectedMove) && moveBuffer.length === 1 && normalized.length === 1) {
+				const validFirstMoves = getSliceFirstMoves(expectedMove);
+				couldBeSliceMove = validFirstMoves.includes(normalized[0]);
+			}
+
+			if (!couldBeDoubleMove && !couldBeSliceMove) {
+				validationFeedback = 'incorrect';
+				addUndoMovesFromBuffer();
+			}
+		}
+	}
+
+	function checkPhaseCompletion() {
+		if (currentMoveIndex >= algMovesParsed.length) {
+			if (phase === 'scrambling') {
+				console.log('Scramble finished! Advancing to countdown (TODO)');
+				// Switch to solving for testing step 2
+				phase = 'solving';
+			}
+		}
+	}
+
+	let settingsRef = $state<Settings>();
+	let bluetoothModalOpen = $state(false);
+
+	let latestSavedCube = $derived.by(() => {
+		if (savedCubesState.cubes.length === 0) return null;
+		return [...savedCubesState.cubes].sort((a, b) => b.lastConnected - a.lastConnected)[0];
+	});
+
+	let connectButtonLabel = $derived.by(() => {
+		if (bluetoothState.isConnected) {
+			const saved = bluetoothState.deviceId ? savedCubesState.getCube(bluetoothState.deviceId) : null;
+			return saved?.customName || bluetoothState.deviceName || 'Connected';
+		}
+		if (latestSavedCube) return latestSavedCube.customName;
+		return 'Connect Cube';
+	});
+
+	async function handleSmartConnect() {
+		if (bluetoothState.isConnected) {
+			bluetoothModalOpen = true;
+			return;
+		}
+		if (latestSavedCube) {
+			await connectSavedCube(latestSavedCube.id);
+		} else {
+			await connectNewCube();
+		}
+	}
+	
+	let completedMoves = $derived(algMovesParsed.slice(0, currentMoveIndex));
+	let currentMoves = $derived(
+		currentMoveIndex < algMovesParsed.length ? [algMovesParsed[currentMoveIndex]] : []
+	);
+	let futureMoves = $derived(
+		currentMoveIndex < algMovesParsed.length ? algMovesParsed.slice(currentMoveIndex + 1) : []
+	);
+
+	// Tailwind classes for scramble guide
+	const completedChipClass =
+		'rounded bg-green-100 dark:bg-green-900 px-2 py-1 font-mono font-semibold text-green-700 dark:text-green-300 opacity-70';
+	const currentChipClass =
+		'rounded bg-blue-500 dark:bg-blue-600 px-2 py-1 font-mono font-semibold text-white animate-pulse shadow-lg';
+	const futureChipVisible =
+		'rounded bg-gray-100 dark:bg-gray-700 px-2 py-1 font-mono font-semibold text-gray-600 dark:text-gray-400';
+	const undoChipClass =
+		'rounded bg-amber-500 dark:bg-amber-600 px-2 py-1 font-mono font-semibold text-white shadow-md';
+
+	const getContainerFeedbackClass = (feedback: 'correct' | 'incorrect' | 'neutral') => {
+		if (feedback === 'correct') return 'border-green-500 bg-green-50 dark:bg-green-950/20';
+		if (feedback === 'incorrect') return 'border-red-500 bg-red-50 dark:bg-red-950/20 animate-shake';
+		return 'border-transparent';
+	};
+
+	async function onNext() {
+		// Just for testing step 2 - advance immediately
+		advanceToNextTrainCase();
+		await tick();
+		phase = 'scrambling';
+		twistyPlayerRef?.reset();
+		movesAdded = '';
+	}
 </script>
 
-<div class="flex h-full w-full flex-col items-center justify-center text-center p-8">
-	<h2 class="text-2xl font-bold mb-4">TrainClassicScramble</h2>
-	<p class="text-gray-500">This mode is currently under construction.</p>
+{#if bluetoothState.isConnected}
+	<div class="my-2 flex items-center justify-center gap-0 sm:gap-2 md:my-4 md:gap-4"></div>
+
+	<!-- Scramble guide (always visible in scramble phase) -->
+	{#if phase === 'scrambling'}
+		<div class="my-2 flex w-full flex-col items-center md:my-4">
+			<div class="mb-2 text-center text-sm font-bold uppercase tracking-widest text-primary-600">
+				Scramble
+			</div>
+			<div
+				class="flex min-w-48 flex-wrap items-center justify-center gap-1 rounded-lg border-2 p-3 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
+					validationFeedback
+				)}"
+			>
+				{#each completedMoves as move}
+					<span class={completedChipClass}>{move}</span>
+				{/each}
+
+				{#if currentMoves.length > 0}
+					{#each currentMoves as move}
+						<span class={currentChipClass}>{move}</span>
+					{/each}
+				{/if}
+
+				{#each futureMoves as move}
+					<span class={futureChipVisible}>{move}</span>
+				{/each}
+			</div>
+
+			{#if undoMoves.length > 0}
+				<div
+					class="mt-3 flex flex-col items-center gap-2 rounded-lg border-2 border-amber-400 bg-amber-50 p-3 dark:border-amber-600 dark:bg-amber-950/30"
+				>
+					<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+						<Undo2 class="size-5" strokeWidth={2.5} />
+						<span class="text-sm font-semibold tracking-wide uppercase">Undo Required</span>
+					</div>
+					<div class="flex flex-wrap items-center justify-center gap-1">
+						{#each undoMoves as move}
+							<span class={undoChipClass}>{move}</span>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<div
+		class="relative mx-auto size-50 md:size-60"
+		onpointerdowncapture={() => {
+			globalState.hasUsedTwistyPlayer = true;
+		}}
+	>
+		{#if phase === 'transitioning'}
+			<div
+				class="absolute inset-0 z-50 flex animate-pulse items-center justify-center rounded-xl bg-green-500/20 backdrop-blur-[1px] transition-all duration-300"
+			>
+				<Check size={80} class="text-green-600 drop-shadow-lg dark:text-green-400" />
+			</div>
+		{/if}
+
+		{#if showRotationWarning && phase !== 'transitioning'}
+			<div
+				transition:fade={{ duration: 300 }}
+				class="absolute inset-0 z-50 flex flex-col items-center justify-center gap-2 rounded-xl bg-yellow-500/20 backdrop-blur-[1px]"
+			>
+				<RotateCcw size={60} class="text-yellow-600 drop-shadow-lg dark:text-yellow-400" />
+				<div class="text-center text-3xl font-bold text-yellow-600 drop-shadow-sm dark:text-yellow-400">
+					Rotate to<br />Home Position
+				</div>
+			</div>
+		{/if}
+
+		{#if currentTrainCase}
+			<TwistyPlayer
+				bind:this={twistyPlayerRef}
+				groupId={currentTrainCase.groupId}
+				caseId={currentTrainCase.caseId}
+				algorithmSelection={currentAlgorithmSelection}
+				auf={currentTrainCase.auf}
+				side={currentTrainCase.side}
+				crossColor={currentTrainCase.crossColor}
+				frontColor={currentTrainCase.frontColor}
+				enableEOColoring={sessionState.activeSession?.settings.trainLearnEO ?? DEFAULT_SETTINGS.trainLearnEO}
+				scrambleSelection={currentTrainCase.scramble}
+				stickering={sessionState.activeSession?.settings.trainHintStickering ?? DEFAULT_SETTINGS.trainHintStickering}
+				backView={sessionState.activeSession?.settings.backView || 'none'}
+				backViewEnabled={sessionState.activeSession?.settings.backViewEnabled || false}
+				experimentalDragInput="auto"
+				class="size-full"
+				controlPanel="none"
+				showVisibilityToggle={false}
+				tempoScale={5}
+				showAlg={false}
+				disableAutoScramble={phase === 'scrambling'}
+				hidePlayer={phase === 'scrambling' && !(sessionState.activeSession?.settings.scrambleShowCube ?? true)}
+				onF2LSolved={() => {
+					if (phase === 'solving' || phase === 'executing') {
+						phase = 'transitioning';
+						setTimeout(() => {
+							onNext();
+						}, 500);
+					}
+				}}
+			/>
+			{#if !globalState.hasUsedTwistyPlayer}
+				<Pointer
+					class="pointer-events-none absolute top-1/2 left-1/2 z-10 size-15 -translate-x-1/2 -translate-y-1/2 animate-bounce text-primary-600"
+				/>
+			{/if}
+		{:else}
+			<div class="flex h-60 items-center justify-center">
+				<P>Loading case...</P>
+			</div>
+		{/if}
+	</div>
+
+	{#if undoMoves.length >= 2}
+		<div class="mt-2 flex justify-center">
+			<span class="text-md rounded-full bg-purple-600 px-3 py-1 font-semibold text-white shadow-md">
+				Hold Green Front, White Up
+			</span>
+		</div>
+	{/if}
+
+	<HintButtonSmart
+		alg={displayAlg}
+		movesAdded={phase === 'scrambling' ? '' : movesAdded}
+		currentMoveIndex={phase === 'scrambling' ? 0 : currentMoveIndex}
+		validationFeedback={phase === 'scrambling' ? 'neutral' : validationFeedback}
+		undoMoves={phase === 'scrambling' ? [] : undoMoves}
+		editDisabled={true}
+		hintMode={'always'}
+		hasMadeFirstMove={phase !== 'scrambling'}
+		onEditAlg={() => {}}
+	/>
+
+	<RecapProgress />
+{:else}
+	<div class="flex flex-col items-center justify-center gap-6 py-20">
+		<div class="flex flex-col items-center gap-3">
+			<P class="text-center text-sm text-gray-500 dark:text-gray-400">
+				Connect a smart cube to start training
+			</P>
+			<ButtonGroup>
+				<Button color="light" onclick={handleSmartConnect} disabled={bluetoothState.isConnecting}>
+					{#if bluetoothState.isConnecting}
+						<Spinner class="mr-2" size="5" />
+						<span class="text-base font-medium">Connecting...</span>
+					{:else}
+						<Bluetooth class="mr-2 size-5" />
+						<span class="text-base font-medium">{connectButtonLabel}</span>
+					{/if}
+				</Button>
+				<Button color="light" onclick={() => (bluetoothModalOpen = true)}>
+					<EllipsisVertical class="size-5" />
+				</Button>
+			</ButtonGroup>
+		</div>
+	</div>
+{/if}
+
+<div class="flex flex-row items-center justify-center gap-2">
+	<TrainStateSelect
+		onremove={async () => {
+			advanceToNextTrainCase();
+			await tick();
+			phase = 'scrambling';
+		}}
+	/>
+	<span class="text-sm text-gray-500 dark:text-gray-400"
+		>{getNumberOfSelectedCases()} cases selected</span
+	>
 </div>
+
+<Details />
+
+<Settings bind:this={settingsRef} />
+<BluetoothModal bind:open={bluetoothModalOpen} />
+
+{#if currentTrainCase}
+	<EditAlg
+		bind:this={editAlgRef}
+		groupId={currentTrainCase.groupId}
+		caseId={currentTrainCase.caseId}
+		side={currentTrainCase.side}
+	/>
+{/if}
+
+<div class="h-20 w-full shrink-0"></div>

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -172,18 +172,21 @@
 
 	// Reset state when case changes
 	$effect(() => {
-		if (currentTrainCase && currentTrainCase.solveId === undefined && phase === 'scrambling') {
+		if (currentTrainCase && currentTrainCase.solveId === undefined) {
 			untrack(() => {
+				phase = 'scrambling';
 				moveBuffer = [];
 				currentMoveIndex = 0;
 				validationFeedback = 'neutral';
 				cumulativeRotation = '';
+				undoMoves = [];
 				movesAdded = '';
 				caseHasRotation = false;
 				showRotationWarning = false;
 				showTargetSolvedCheck = false;
 				if (checkTimeoutId) clearTimeout(checkTimeoutId);
 				drillTimerRef?.reset();
+				twistyPlayerRef?.reset();
 			});
 		}
 	});
@@ -508,6 +511,7 @@
 		drillTimerRef?.reset();
 		advanceToNextTrainCase();
 		phase = 'scrambling';
+		undoMoves = [];
 		twistyPlayerRef?.reset();
 		movesAdded = '';
 	}
@@ -516,6 +520,7 @@
 		drillTimerRef?.reset();
 		advanceToPreviousTrainCase();
 		phase = 'scrambling';
+		undoMoves = [];
 		twistyPlayerRef?.reset();
 		movesAdded = '';
 	}

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+</script>
+
+<div class="flex h-full w-full flex-col items-center justify-center text-center p-8">
+	<h2 class="text-2xl font-bold mb-4">TrainClassicScramble</h2>
+	<p class="text-gray-500">This mode is currently under construction.</p>
+</div>

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -757,7 +757,7 @@
 		</div>
 
 		{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
-			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual'}
+			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual' && (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'always'}
 				<HintButton
 					alg={displayAlg}
 					visible={true}

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -56,8 +56,17 @@
 	import { simplifyAlg } from '$lib/utils/simplifyAlg';
 	import getRotationAlg from '$lib/rotation';
 
-	type Phase = 'scrambling' | 'countdown' | 'solving' | 'executing' | 'transitioning';
+	type Phase =
+		| 'scrambling'
+		| 'countdown'
+		| 'solving'
+		| 'executing'
+		| 'finishing_f2l'
+		| 'transitioning';
 	let phase = $state<Phase>('scrambling');
+
+	let showTargetSolvedCheck = $state(false);
+	let checkTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
 	let editAlgRef = $state<EditAlg>();
 	let twistyPlayerRef = $state<any>();
@@ -160,6 +169,8 @@
 				movesAdded = '';
 				caseHasRotation = false;
 				showRotationWarning = false;
+				showTargetSolvedCheck = false;
+				if (checkTimeoutId) clearTimeout(checkTimeoutId);
 				drillTimerRef?.reset();
 			});
 		}
@@ -548,9 +559,10 @@
 			globalState.hasUsedTwistyPlayer = true;
 		}}
 	>
-		{#if phase === 'transitioning'}
+		{#if showTargetSolvedCheck}
 			<div
-				class="absolute inset-0 z-50 flex animate-pulse items-center justify-center rounded-xl bg-green-500/20 backdrop-blur-[1px] transition-all duration-300"
+				transition:fade={{ duration: 300 }}
+				class="pointer-events-none absolute inset-0 z-50 flex animate-pulse items-center justify-center rounded-xl bg-green-500/20 backdrop-blur-[1px]"
 			>
 				<Check size={80} class="text-green-600 drop-shadow-lg dark:text-green-400" />
 			</div>
@@ -602,6 +614,18 @@
 			</div>
 		{/if}
 
+		{#if phase === 'finishing_f2l'}
+			<div
+				class="pointer-events-none absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/40 transition-all duration-300"
+			>
+				<div
+					class="scale-100 transform rounded-2xl bg-gray-900/80 px-8 py-6 text-center shadow-2xl ring-1 ring-white/20 transition-all duration-300"
+				>
+					<p class="mb-2 text-xl font-bold text-white drop-shadow-md">Solve the rest of F2L</p>
+				</div>
+			</div>
+		{/if}
+
 		{#if currentTrainCase}
 			<TwistyPlayer
 				bind:this={twistyPlayerRef}
@@ -615,9 +639,11 @@
 				enableEOColoring={sessionState.activeSession?.settings.trainLearnEO ??
 					DEFAULT_SETTINGS.trainLearnEO}
 				scrambleSelection={currentTrainCase.scramble}
-				stickering={phase === 'scrambling' && !(sessionState.activeSession?.settings.scrambleShowCube ?? true)
+				stickering={phase === 'scrambling' &&
+				!(sessionState.activeSession?.settings.scrambleShowCube ?? true)
 					? 'centers-only'
-					: (sessionState.activeSession?.settings.trainHintStickering ?? DEFAULT_SETTINGS.trainHintStickering)}
+					: (sessionState.activeSession?.settings.trainHintStickering ??
+						DEFAULT_SETTINGS.trainHintStickering)}
 				backView={sessionState.activeSession?.settings.backView || 'none'}
 				backViewEnabled={sessionState.activeSession?.settings.backViewEnabled || false}
 				experimentalDragInput="auto"
@@ -628,7 +654,7 @@
 				showAlg={false}
 				disableAutoScramble={phase === 'scrambling'}
 				hidePlayer={phase === 'countdown'}
-				onF2LSolved={() => {
+				onF2LSolved={(entireF2LSolved) => {
 					if (phase === 'solving' || phase === 'executing') {
 						const executionTime = drillTimerRef?.stopExecution() ?? 0;
 						const recognitionTime = drillTimerRef?.getRecognitionTime() ?? 0;
@@ -637,6 +663,7 @@
 							const totalTime = recognitionTime + executionTime;
 							currentTrainCase.time = totalTime;
 							currentTrainCase.solveId = crypto.randomUUID();
+
 							trainState.lastDisplayedTime = totalTime;
 
 							statisticsState.addSolve({
@@ -653,9 +680,19 @@
 								executionTime,
 								trainMode: 'smartScramble'
 							});
+
 							currentTrainCase.solved = true;
 						}
 
+						phase = 'finishing_f2l';
+						showTargetSolvedCheck = true;
+						if (checkTimeoutId) clearTimeout(checkTimeoutId);
+						checkTimeoutId = setTimeout(() => {
+							showTargetSolvedCheck = false;
+						}, 1000);
+					}
+
+					if (entireF2LSolved && phase === 'finishing_f2l') {
 						phase = 'transitioning';
 						setTimeout(() => {
 							onNext();

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -757,7 +757,7 @@
 		</div>
 
 		{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
-			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual' && (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'always'}
+			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual'}
 				<HintButton
 					alg={displayAlg}
 					visible={true}

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -60,6 +60,12 @@
 	let movesAdded = $state('');
 	let caseHasRotation = $state(false);
 
+	let countdownDuration = $derived(
+		sessionState.activeSession?.settings.scrambleCountdownDuration ??
+			DEFAULT_SETTINGS.scrambleCountdownDuration ??
+			1.0
+	);
+
 	const SUBSCRIBER_ID = 'train-classic-scramble';
 	const SUBSCRIBER_PRIORITY = 50;
 
@@ -313,12 +319,21 @@
 		}
 	}
 
-	function checkPhaseCompletion() {
+	async function checkPhaseCompletion() {
 		if (currentMoveIndex >= algMovesParsed.length) {
 			if (phase === 'scrambling') {
-				console.log('Scramble finished! Advancing to countdown (TODO)');
-				// Switch to solving for testing step 2
-				phase = 'solving';
+				phase = 'countdown';
+				
+				// Ensure UI has updated
+				await tick();
+				
+				// Wait for countdown duration
+				await new Promise((resolve) => setTimeout(resolve, countdownDuration * 1000));
+				
+				// Ensure phase hasn't changed (e.g. skipped)
+				if (phase === 'countdown') {
+					phase = 'solving';
+				}
 			}
 		}
 	}
@@ -459,6 +474,41 @@
 			</div>
 		{/if}
 
+		{#if phase === 'countdown'}
+			<div
+				class="absolute inset-0 z-50 flex flex-col items-center justify-center gap-4 rounded-xl bg-gray-100 dark:bg-gray-800"
+			>
+				<div class="relative flex items-center justify-center">
+					<svg class="size-32 -rotate-90 transform overflow-visible">
+						<circle
+							cx="64"
+							cy="64"
+							r="56"
+							stroke="currentColor"
+							stroke-width="8"
+							fill="transparent"
+							class="text-primary-200 dark:text-primary-900"
+						/>
+						<circle
+							cx="64"
+							cy="64"
+							r="56"
+							stroke="currentColor"
+							stroke-width="8"
+							fill="transparent"
+							class="radial-countdown text-primary-500"
+							stroke-dasharray="352"
+							stroke-dashoffset="0"
+							style="--duration: {countdownDuration}s"
+						/>
+					</svg>
+				</div>
+				<span class="text-md rounded-full bg-purple-600 px-3 py-1 font-semibold text-white shadow-md">
+					Hold Green Front, White Up
+				</span>
+			</div>
+		{/if}
+
 		{#if currentTrainCase}
 			<TwistyPlayer
 				bind:this={twistyPlayerRef}
@@ -481,7 +531,7 @@
 				tempoScale={5}
 				showAlg={false}
 				disableAutoScramble={phase === 'scrambling'}
-				hidePlayer={phase === 'scrambling' && !(sessionState.activeSession?.settings.scrambleShowCube ?? true)}
+				hidePlayer={phase === 'countdown' || (phase === 'scrambling' && !(sessionState.activeSession?.settings.scrambleShowCube ?? true))}
 				onF2LSolved={() => {
 					if (phase === 'solving' || phase === 'executing') {
 						phase = 'transitioning';
@@ -503,7 +553,7 @@
 		{/if}
 	</div>
 
-	{#if undoMoves.length >= 2}
+	{#if undoMoves.length >= 2 && phase !== 'countdown'}
 		<div class="mt-2 flex justify-center">
 			<span class="text-md rounded-full bg-purple-600 px-3 py-1 font-semibold text-white shadow-md">
 				Hold Green Front, White Up
@@ -576,3 +626,15 @@
 {/if}
 
 <div class="h-20 w-full shrink-0"></div>
+
+<style>
+	@keyframes countdown {
+		to {
+			stroke-dashoffset: 352;
+		}
+	}
+
+	.radial-countdown {
+		animation: countdown var(--duration) linear forwards;
+	}
+</style>

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -3,6 +3,7 @@
 	import TwistyPlayer from '../TwistyPlayer.svelte';
 	import {
 		advanceToNextTrainCase,
+		advanceToPreviousTrainCase,
 		getNumberOfSelectedCases,
 		trainState
 	} from '$lib/trainCaseQueue.svelte';
@@ -17,7 +18,7 @@
 	import HintButtonSmart from './HintButtonSmart.svelte';
 	import DrillTimer from './DrillTimer.svelte';
 	import { globalState } from '$lib/globalState.svelte';
-	import { Pointer, Check, RotateCcw, Bluetooth, EllipsisVertical, Undo2 } from '@lucide/svelte';
+	import { Pointer, Check, RotateCcw, Bluetooth, EllipsisVertical, Undo2, ArrowLeft, ArrowRight } from '@lucide/svelte';
 	import Details from './Details.svelte';
 	import TrainStateSelect from './TrainStateSelect.svelte';
 	import RecapProgress from './RecapProgress.svelte';
@@ -419,54 +420,73 @@
 		twistyPlayerRef?.reset();
 		movesAdded = '';
 	}
+
+	function onPrevious() {
+		drillTimerRef?.reset();
+		advanceToPreviousTrainCase();
+		phase = 'scrambling';
+		twistyPlayerRef?.reset();
+		movesAdded = '';
+	}
 </script>
 
 {#if bluetoothState.isConnected}
-	<div class="my-2 flex items-center justify-center gap-0 sm:gap-2 md:my-4 md:gap-4"></div>
-
-	<!-- Scramble guide (always visible in scramble phase) -->
-	{#if phase === 'scrambling'}
-		<div class="my-2 flex w-full flex-col items-center md:my-4">
-			<div class="mb-2 text-center text-sm font-bold uppercase tracking-widest text-primary-600">
-				Scramble
-			</div>
-			<div
-				class="flex min-w-48 flex-wrap items-center justify-center gap-1 rounded-lg border-2 p-3 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
-					validationFeedback
-				)}"
-			>
-				{#each completedMoves as move}
-					<span class={completedChipClass}>{move}</span>
-				{/each}
-
-				{#if currentMoves.length > 0}
-					{#each currentMoves as move}
-						<span class={currentChipClass}>{move}</span>
-					{/each}
-				{/if}
-
-				{#each futureMoves as move}
-					<span class={futureChipVisible}>{move}</span>
-				{/each}
-			</div>
-
-			{#if undoMoves.length > 0}
+	<div class="my-2 flex items-center justify-center gap-0 sm:gap-2 md:my-4 md:gap-4">
+		<Button class="btn-icon-transparent shrink-0" type="button" onclick={onPrevious}>
+			<ArrowLeft class="size-8 text-primary-600 md:size-12" />
+		</Button>
+		
+		<div class="flex flex-col items-center">
+			<!-- Scramble guide (maintains layout space when hidden) -->
+			<div class="flex flex-col items-center transition-opacity duration-200 {phase !== 'scrambling' ? 'opacity-0 pointer-events-none' : 'opacity-100'}">
 				<div
-					class="mt-3 flex flex-col items-center gap-2 rounded-lg border-2 border-amber-400 bg-amber-50 p-3 dark:border-amber-600 dark:bg-amber-950/30"
+					class="flex min-w-48 flex-wrap items-center justify-center gap-1 rounded-lg border-2 p-3 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
+						validationFeedback
+					)}"
 				>
-					<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
-						<Undo2 class="size-5" strokeWidth={2.5} />
-						<span class="text-sm font-semibold tracking-wide uppercase">Undo Required</span>
-					</div>
-					<div class="flex flex-wrap items-center justify-center gap-1">
-						{#each undoMoves as move}
-							<span class={undoChipClass}>{move}</span>
+					{#if phase === 'scrambling'}
+						{#each completedMoves as move}
+							<span class={completedChipClass}>{move}</span>
 						{/each}
-					</div>
+
+						{#if currentMoves.length > 0}
+							{#each currentMoves as move}
+								<span class={currentChipClass}>{move}</span>
+							{/each}
+						{/if}
+
+						{#each futureMoves as move}
+							<span class={futureChipVisible}>{move}</span>
+						{/each}
+					{:else}
+						{#each displayScramble.replace(/[()]/g, '').split(' ').filter((m) => m.trim() !== '') as move}
+							<span class={completedChipClass}>{move}</span>
+						{/each}
+					{/if}
 				</div>
-			{/if}
+
+				{#if undoMoves.length > 0 && phase === 'scrambling'}
+					<div
+						class="mt-3 flex flex-col items-center gap-2 rounded-lg border-2 border-amber-400 bg-amber-50 p-3 dark:border-amber-600 dark:bg-amber-950/30"
+					>
+						<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+							<Undo2 class="size-5" strokeWidth={2.5} />
+							<span class="text-sm font-semibold tracking-wide uppercase">Undo Required</span>
+						</div>
+						<div class="flex flex-wrap items-center justify-center gap-1">
+							{#each undoMoves as move}
+								<span class={undoChipClass}>{move}</span>
+							{/each}
+						</div>
+					</div>
+				{/if}
+			</div>
 		</div>
-	{/if}
+
+		<Button class="btn-icon-transparent shrink-0" type="button" onclick={onNext}>
+			<ArrowRight class="size-8 text-primary-600 md:size-12" />
+		</Button>
+	</div>
 
 	<div
 		class="relative mx-auto size-50 md:size-60"

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -228,8 +228,10 @@
 				sessionState.activeSession?.settings.trainHintAlgorithm ??
 				DEFAULT_SETTINGS.trainHintAlgorithm;
 			const hintBehavior =
-				sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
-			const isAlgorithmValidationActive = phase === 'scrambling' || (hintAlgorithm !== 'hidden' && hintBehavior !== 'manual');
+				sessionState.activeSession?.settings.smartHintBehavior ??
+				DEFAULT_SETTINGS.smartHintBehavior;
+			const isAlgorithmValidationActive =
+				phase === 'scrambling' || (hintAlgorithm !== 'hidden' && hintBehavior !== 'manual');
 
 			let isNextWideMove = false;
 			if (isAlgorithmValidationActive) {
@@ -551,7 +553,7 @@
 					: 'opacity-100'}"
 			>
 				<div
-					class="relative flex min-w-48 flex-wrap items-center justify-center gap-1 overflow-hidden rounded-lg border-2 p-3 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
+					class="relative flex min-w-48 flex-wrap items-center justify-center gap-1 overflow-hidden rounded-lg border-2 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
 						validationFeedback
 					)}"
 				>

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -463,7 +463,6 @@
 		'rounded bg-amber-500 dark:bg-amber-600 px-2 py-1 font-mono font-semibold text-white shadow-md';
 
 	const getContainerFeedbackClass = (feedback: 'correct' | 'incorrect' | 'neutral') => {
-		if (feedback === 'correct') return 'border-green-500 bg-green-50 dark:bg-green-950/20';
 		if (feedback === 'incorrect')
 			return 'border-red-500 bg-red-50 dark:bg-red-950/20 animate-shake';
 		return 'border-transparent';
@@ -616,10 +615,10 @@
 
 		{#if phase === 'finishing_f2l'}
 			<div
-				class="pointer-events-none absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/40 transition-all duration-300"
+				class="pointer-events-none absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/40 backdrop-blur-sm transition-all duration-300"
 			>
 				<div
-					class="scale-100 transform rounded-2xl bg-gray-900/80 px-8 py-6 text-center shadow-2xl ring-1 ring-white/20 transition-all duration-300"
+					class="scale-100 transform rounded-2xl bg-gray-900/80 px-8 py-6 text-center shadow-2xl ring-1 ring-white/20 backdrop-blur-md transition-all duration-300"
 				>
 					<p class="mb-2 text-xl font-bold text-white drop-shadow-md">Solve the rest of F2L</p>
 				</div>

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -16,6 +16,8 @@
 	import { casesStatic } from '$lib/casesStatic';
 	import { concatinateAuf } from '$lib/utils/addAuf';
 	import HintButtonSmart from './HintButtonSmart.svelte';
+	import HintButton from './HintButton.svelte';
+	import { createHintManager } from '$lib/utils/hintManager.svelte';
 	import DrillTimer from './DrillTimer.svelte';
 	import { globalState } from '$lib/globalState.svelte';
 	import {
@@ -71,6 +73,17 @@
 	let editAlgRef = $state<EditAlg>();
 	let twistyPlayerRef = $state<any>();
 	let drillTimerRef = $state<DrillTimer>();
+
+	const hintManager = createHintManager();
+
+	function showHintAlg() {
+		hintManager.revealHint(
+			sessionState.activeSession?.settings.trainHintAlgorithm ??
+				DEFAULT_SETTINGS.trainHintAlgorithm,
+			displayAlg,
+			false // twistyAlgViewerLoaded is false for smart modes
+		);
+	}
 
 	let displayScramble = $state('');
 	let displayAlg = $state('');
@@ -159,13 +172,12 @@
 
 	// Reset state when case changes
 	$effect(() => {
-		if (currentTrainCase) {
+		if (currentTrainCase && currentTrainCase.solveId === undefined && phase === 'scrambling') {
 			untrack(() => {
-				currentMoveIndex = 0;
 				moveBuffer = [];
+				currentMoveIndex = 0;
 				validationFeedback = 'neutral';
 				cumulativeRotation = '';
-				undoMoves = [];
 				movesAdded = '';
 				caseHasRotation = false;
 				showRotationWarning = false;
@@ -173,6 +185,18 @@
 				if (checkTimeoutId) clearTimeout(checkTimeoutId);
 				drillTimerRef?.reset();
 			});
+		}
+	});
+
+	$effect(() => {
+		void currentTrainCase;
+		if (currentTrainCase) {
+			hintManager.reset();
+			hintManager.initialize(
+				sessionState.activeSession?.settings.trainHintAlgorithm ??
+					DEFAULT_SETTINGS.trainHintAlgorithm,
+				false
+			);
 		}
 	});
 
@@ -267,9 +291,12 @@
 	}
 
 	function validateMoveProgress() {
-		// Disable algorithm validation and auto-rotation if the hint is hidden
+		// Disable algorithm validation and auto-rotation if the hint is hidden or manual
 		// (but ONLY during the solving phases, we still need to validate the scramble!)
-		if (phase !== 'scrambling' && (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) === 'hidden') {
+		const hintAlgorithm = sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm;
+		const hintBehavior = sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
+		
+		if (phase !== 'scrambling' && (hintAlgorithm === 'hidden' || hintBehavior === 'manual')) {
 			return;
 		}
 
@@ -727,22 +754,37 @@
 		</div>
 
 		{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
-		<HintButtonSmart
-			alg={displayAlg}
-			movesAdded={phase === 'scrambling' || phase === 'countdown' ? '' : movesAdded}
-			currentMoveIndex={phase === 'scrambling' || phase === 'countdown' ? 0 : currentMoveIndex}
-			validationFeedback={phase === 'scrambling' || phase === 'countdown'
-				? 'neutral'
-				: validationFeedback}
-			undoMoves={phase === 'scrambling' || phase === 'countdown' ? [] : undoMoves}
-			editDisabled={currentMoveIndex > 0 || movesAdded.trim() !== ''}
-			hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
-				DEFAULT_SETTINGS.trainHintAlgorithm}
-			hasMadeFirstMove={phase === 'executing' || phase === 'transitioning'}
-			onEditAlg={() => {
-				editAlgRef?.openModal();
-			}}
-		/>
+			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual'}
+				<HintButton
+					alg={displayAlg}
+					visible={true}
+					hintCounter={hintManager.counter}
+					hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
+						DEFAULT_SETTINGS.trainHintAlgorithm}
+					onclick={showHintAlg}
+					onEditAlg={() => {
+						editAlgRef?.openModal();
+					}}
+					showAlgViewer={false}
+				/>
+			{:else}
+				<HintButtonSmart
+					alg={displayAlg}
+					movesAdded={phase === 'scrambling' || phase === 'countdown' ? '' : movesAdded}
+					currentMoveIndex={phase === 'scrambling' || phase === 'countdown' ? 0 : currentMoveIndex}
+					validationFeedback={phase === 'scrambling' || phase === 'countdown'
+						? 'neutral'
+						: validationFeedback}
+					undoMoves={phase === 'scrambling' || phase === 'countdown' ? [] : undoMoves}
+					editDisabled={currentMoveIndex > 0 || movesAdded.trim() !== ''}
+					hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
+						DEFAULT_SETTINGS.trainHintAlgorithm}
+					hasMadeFirstMove={phase === 'executing' || phase === 'transitioning'}
+					onEditAlg={() => {
+						editAlgRef?.openModal();
+					}}
+				/>
+			{/if}
 		{/if}
 	</div>
 

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -440,7 +440,7 @@
 			<!-- Scramble guide (maintains layout space when hidden) -->
 			<div class="flex flex-col items-center transition-opacity duration-200 {phase !== 'scrambling' ? 'opacity-0 pointer-events-none' : 'opacity-100'}">
 				<div
-					class="flex min-w-48 flex-wrap items-center justify-center gap-1 rounded-lg border-2 p-3 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
+					class="relative overflow-hidden flex min-w-48 flex-wrap items-center justify-center gap-1 rounded-lg border-2 p-3 font-mono text-xl font-semibold transition-colors md:text-3xl {getContainerFeedbackClass(
 						validationFeedback
 					)}"
 				>
@@ -463,23 +463,23 @@
 							<span class={completedChipClass}>{move}</span>
 						{/each}
 					{/if}
-				</div>
 
-				{#if undoMoves.length > 0 && phase === 'scrambling'}
-					<div
-						class="mt-3 flex flex-col items-center gap-2 rounded-lg border-2 border-amber-400 bg-amber-50 p-3 dark:border-amber-600 dark:bg-amber-950/30"
-					>
-						<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
-							<Undo2 class="size-5" strokeWidth={2.5} />
-							<span class="text-sm font-semibold tracking-wide uppercase">Undo Required</span>
+					{#if undoMoves.length > 0 && phase === 'scrambling'}
+						<div
+							class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 bg-amber-50/95 p-2 backdrop-blur-[2px] dark:bg-amber-950/95"
+						>
+							<div class="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+								<Undo2 class="size-4 md:size-5" strokeWidth={2.5} />
+								<span class="text-xs font-semibold tracking-wide uppercase md:text-sm">Undo Required</span>
+							</div>
+							<div class="flex flex-wrap items-center justify-center gap-1">
+								{#each undoMoves as move}
+									<span class={undoChipClass}>{move}</span>
+								{/each}
+							</div>
 						</div>
-						<div class="flex flex-wrap items-center justify-center gap-1">
-							{#each undoMoves as move}
-								<span class={undoChipClass}>{move}</span>
-							{/each}
-						</div>
-					</div>
-				{/if}
+					{/if}
+				</div>
 			</div>
 		</div>
 
@@ -543,9 +543,6 @@
 						/>
 					</svg>
 				</div>
-				<span class="text-md rounded-full bg-purple-600 px-3 py-1 font-semibold text-white shadow-md">
-					Hold Green Front, White Up
-				</span>
 			</div>
 		{/if}
 
@@ -619,24 +616,16 @@
 		{/if}
 	</div>
 
-	{#if undoMoves.length >= 2 && phase !== 'countdown'}
-		<div class="mt-2 flex justify-center">
-			<span class="text-md rounded-full bg-purple-600 px-3 py-1 font-semibold text-white shadow-md">
-				Hold Green Front, White Up
-			</span>
-		</div>
-	{/if}
 
-	{#if phase !== 'scrambling' && phase !== 'countdown'}
-		<div
-			class="mt-2"
-			class:hidden={!(
-				sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer
-			)}
-		>
-			<DrillTimer bind:this={drillTimerRef} />
-		</div>
-	{/if}
+
+	<div
+		class="mt-2"
+		class:hidden={!(
+			sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer
+		)}
+	>
+		<DrillTimer bind:this={drillTimerRef} />
+	</div>
 
 	<HintButtonSmart
 		alg={displayAlg}

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -223,15 +223,26 @@
 		try {
 			moveBuffer = [...moveBuffer, m];
 
-			let lookAheadIndex = currentMoveIndex;
-			while (
-				lookAheadIndex < algMovesParsed.length &&
-				isRotationMove(algMovesParsed[lookAheadIndex])
-			) {
-				lookAheadIndex++;
+			// Check if algorithm validation is active
+			const hintAlgorithm =
+				sessionState.activeSession?.settings.trainHintAlgorithm ??
+				DEFAULT_SETTINGS.trainHintAlgorithm;
+			const hintBehavior =
+				sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
+			const isAlgorithmValidationActive = phase === 'scrambling' || (hintAlgorithm !== 'hidden' && hintBehavior !== 'manual');
+
+			let isNextWideMove = false;
+			if (isAlgorithmValidationActive) {
+				let lookAheadIndex = currentMoveIndex;
+				while (
+					lookAheadIndex < algMovesParsed.length &&
+					isRotationMove(algMovesParsed[lookAheadIndex])
+				) {
+					lookAheadIndex++;
+				}
+				const nextNonRotationMove = algMovesParsed[lookAheadIndex];
+				isNextWideMove = !!(nextNonRotationMove && isWideMove(nextNonRotationMove));
 			}
-			const nextNonRotationMove = algMovesParsed[lookAheadIndex];
-			const isNextWideMove = nextNonRotationMove && isWideMove(nextNonRotationMove);
 
 			const inverseRot = inverseRotation(cumulativeRotation);
 			const transformedMove = applyRotationToMove(m, inverseRot);

--- a/src/lib/components/TrainView/TrainClassicScramble.svelte
+++ b/src/lib/components/TrainView/TrainClassicScramble.svelte
@@ -615,8 +615,9 @@
 				enableEOColoring={sessionState.activeSession?.settings.trainLearnEO ??
 					DEFAULT_SETTINGS.trainLearnEO}
 				scrambleSelection={currentTrainCase.scramble}
-				stickering={sessionState.activeSession?.settings.trainHintStickering ??
-					DEFAULT_SETTINGS.trainHintStickering}
+				stickering={phase === 'scrambling' && !(sessionState.activeSession?.settings.scrambleShowCube ?? true)
+					? 'centers-only'
+					: (sessionState.activeSession?.settings.trainHintStickering ?? DEFAULT_SETTINGS.trainHintStickering)}
 				backView={sessionState.activeSession?.settings.backView || 'none'}
 				backViewEnabled={sessionState.activeSession?.settings.backViewEnabled || false}
 				experimentalDragInput="auto"
@@ -626,9 +627,7 @@
 				tempoScale={5}
 				showAlg={false}
 				disableAutoScramble={phase === 'scrambling'}
-				hidePlayer={phase === 'countdown' ||
-					(phase === 'scrambling' &&
-						!(sessionState.activeSession?.settings.scrambleShowCube ?? true))}
+				hidePlayer={phase === 'countdown'}
 				onF2LSolved={() => {
 					if (phase === 'solving' || phase === 'executing') {
 						const executionTime = drillTimerRef?.stopExecution() ?? 0;

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -16,6 +16,8 @@
 	import { casesStatic } from '$lib/casesStatic';
 	import { concatinateAuf } from '$lib/utils/addAuf';
 	import HintButtonSmart from './HintButtonSmart.svelte';
+	import HintButton from './HintButton.svelte';
+	import { createHintManager } from '$lib/utils/hintManager.svelte';
 	import { globalState } from '$lib/globalState.svelte';
 	import { Pointer, Check, RotateCcw, Bluetooth, EllipsisVertical } from '@lucide/svelte';
 	import Details from './Details.svelte';
@@ -49,6 +51,16 @@
 	import { createKeyboardHandlers } from './trainViewEventHandlers.svelte';
 
 	let editAlgRef = $state<EditAlg>();
+	const hintManager = createHintManager();
+
+	function showHintAlg() {
+		hintManager.revealHint(
+			sessionState.activeSession?.settings.trainHintAlgorithm ??
+				DEFAULT_SETTINGS.trainHintAlgorithm,
+			displayAlg,
+			false // twistyAlgViewerLoaded is false for smart modes
+		);
+	}
 
 	let smartTimerRef = $state<SmartTimer>();
 	let timerStarted = $state(false); // Track if timer has been started for current case
@@ -146,7 +158,6 @@
 
 	// Subscribe to move events when component is active
 	$effect(() => {
-		// Only subscribe when we have a current train case
 		const hasTrainCase = !!trainState.current;
 
 		if (hasTrainCase) {
@@ -154,6 +165,18 @@
 			return () => {
 				bluetoothState.unsubscribeFromMoves(SUBSCRIBER_ID);
 			};
+		}
+	});
+
+	$effect(() => {
+		void currentTrainCase;
+		if (currentTrainCase) {
+			hintManager.reset();
+			hintManager.initialize(
+				sessionState.activeSession?.settings.trainHintAlgorithm ??
+					DEFAULT_SETTINGS.trainHintAlgorithm,
+				false
+			);
 		}
 	});
 
@@ -198,8 +221,10 @@
 	);
 
 	function validateMoveProgress() {
-		// Disable algorithm validation and auto-rotation if the hint is hidden
-		if ((sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) === 'hidden') {
+		// Disable algorithm validation and auto-rotation if the hint is hidden or manual
+		const hintAlgorithm = sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm;
+		const hintBehavior = sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
+		if (hintAlgorithm === 'hidden' || hintBehavior === 'manual') {
 			return;
 		}
 
@@ -877,20 +902,35 @@
 
 	<div class="my-2 flex w-full flex-col items-center gap-2 md:my-4 md:gap-4">
 		{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
-			<HintButtonSmart
-				alg={displayAlg}
-				movesAdded={alg}
-				{currentMoveIndex}
-				{validationFeedback}
-				{undoMoves}
-				editDisabled={currentMoveIndex > 0 || alg.trim() !== ''}
-				hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
-					DEFAULT_SETTINGS.trainHintAlgorithm}
-				hasMadeFirstMove={timerStarted}
-				onEditAlg={() => {
-					editAlgRef?.openModal();
-				}}
-			/>
+			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual'}
+				<HintButton
+					alg={displayAlg}
+					visible={true}
+					hintCounter={hintManager.counter}
+					hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
+						DEFAULT_SETTINGS.trainHintAlgorithm}
+					onclick={showHintAlg}
+					onEditAlg={() => {
+						editAlgRef?.openModal();
+					}}
+					showAlgViewer={false}
+				/>
+			{:else}
+				<HintButtonSmart
+					alg={displayAlg}
+					movesAdded={alg}
+					{currentMoveIndex}
+					{validationFeedback}
+					{undoMoves}
+					editDisabled={currentMoveIndex > 0 || alg.trim() !== ''}
+					hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
+						DEFAULT_SETTINGS.trainHintAlgorithm}
+					hasMadeFirstMove={timerStarted}
+					onEditAlg={() => {
+						editAlgRef?.openModal();
+					}}
+				/>
+			{/if}
 		{/if}
 		<div
 			class:hidden={!(

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -870,26 +870,30 @@
 		</div>
 	{/if}
 
-	<HintButtonSmart
-		alg={displayAlg}
-		movesAdded={alg}
-		{currentMoveIndex}
-		{validationFeedback}
-		{undoMoves}
-		editDisabled={currentMoveIndex > 0 || alg.trim() !== ''}
-		hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
-			DEFAULT_SETTINGS.trainHintAlgorithm}
-		hasMadeFirstMove={timerStarted}
-		onEditAlg={() => {
-			editAlgRef?.openModal();
-		}}
-	/>
-	<div
-		class:hidden={!(
-			sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer
-		)}
-	>
-		<SmartTimer bind:this={smartTimerRef} initialTime={displayTime} onStop={recordSolveTime} />
+	<div class="my-2 flex w-full flex-col items-center gap-2 md:my-4 md:gap-4">
+		{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
+			<HintButtonSmart
+				alg={displayAlg}
+				movesAdded={alg}
+				{currentMoveIndex}
+				{validationFeedback}
+				{undoMoves}
+				editDisabled={currentMoveIndex > 0 || alg.trim() !== ''}
+				hintMode={sessionState.activeSession?.settings.trainHintAlgorithm ??
+					DEFAULT_SETTINGS.trainHintAlgorithm}
+				hasMadeFirstMove={timerStarted}
+				onEditAlg={() => {
+					editAlgRef?.openModal();
+				}}
+			/>
+		{/if}
+		<div
+			class:hidden={!(
+				sessionState.activeSession?.settings.trainShowTimer ?? DEFAULT_SETTINGS.trainShowTimer
+			)}
+		>
+			<SmartTimer bind:this={smartTimerRef} initialTime={displayTime} onStop={recordSolveTime} />
+		</div>
 	</div>
 
 	<RecapProgress />

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -914,7 +914,7 @@
 
 	<div class="my-2 flex w-full flex-col items-center gap-2 md:my-4 md:gap-4">
 		{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
-			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual'}
+			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual' && (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'always'}
 				<HintButton
 					alg={displayAlg}
 					visible={true}

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -614,6 +614,15 @@
 	}
 
 	async function onNext() {
+		const wasTimerRunning = smartTimerRef?.getIsRunning();
+
+		if (timerStarted && wasTimerRunning) {
+			smartTimerRef?.stopTimer();
+			smartTimerRef?.resetTimer();
+			// User skipped an active case, reset the time to 0 instead of showing previous time
+			trainState.lastDisplayedTime = 0;
+		}
+
 		if (currentTrainCase) {
 			const { groupId, caseId } = currentTrainCase;
 

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -118,7 +118,8 @@
 				sessionState.activeSession?.settings.trainHintAlgorithm ??
 				DEFAULT_SETTINGS.trainHintAlgorithm;
 			const hintBehavior =
-				sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
+				sessionState.activeSession?.settings.smartHintBehavior ??
+				DEFAULT_SETTINGS.smartHintBehavior;
 			const isAlgorithmValidationActive = hintAlgorithm !== 'hidden' && hintBehavior !== 'manual';
 
 			let isNextWideMove = false;

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -113,18 +113,29 @@
 			// Log every raw move from smart cube
 			console.log('%c[Smart Cube Move]', 'color: #e91e63; font-weight: bold', m);
 
-			// Check if the next non-rotation expected move is a wide move
-			// We need to look past rotations because they are auto-applied during validation
-			// and the raw move from the smart cube might be consumed by a wide move after rotations
-			let lookAheadIndex = currentMoveIndex;
-			while (
-				lookAheadIndex < algMovesParsed.length &&
-				isRotationMove(algMovesParsed[lookAheadIndex])
-			) {
-				lookAheadIndex++;
+			// Check if algorithm validation is active
+			const hintAlgorithm =
+				sessionState.activeSession?.settings.trainHintAlgorithm ??
+				DEFAULT_SETTINGS.trainHintAlgorithm;
+			const hintBehavior =
+				sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
+			const isAlgorithmValidationActive = hintAlgorithm !== 'hidden' && hintBehavior !== 'manual';
+
+			let isNextWideMove = false;
+			if (isAlgorithmValidationActive) {
+				// Check if the next non-rotation expected move is a wide move
+				// We need to look past rotations because they are auto-applied during validation
+				// and the raw move from the smart cube might be consumed by a wide move after rotations
+				let lookAheadIndex = currentMoveIndex;
+				while (
+					lookAheadIndex < algMovesParsed.length &&
+					isRotationMove(algMovesParsed[lookAheadIndex])
+				) {
+					lookAheadIndex++;
+				}
+				const nextNonRotationMove = algMovesParsed[lookAheadIndex];
+				isNextWideMove = !!(nextNonRotationMove && isWideMove(nextNonRotationMove));
 			}
-			const nextNonRotationMove = algMovesParsed[lookAheadIndex];
-			const isNextWideMove = nextNonRotationMove && isWideMove(nextNonRotationMove);
 
 			// Transform move for TwistyPlayer (algorithm frame)
 			const inverseRot = inverseRotation(cumulativeRotation);

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -198,6 +198,11 @@
 	);
 
 	function validateMoveProgress() {
+		// Disable algorithm validation and auto-rotation if the hint is hidden
+		if ((sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) === 'hidden') {
+			return;
+		}
+
 		// Check if user is in undo mode (has pending undo moves)
 		if (undoMoves.length > 0) {
 			validateUndoProgress();
@@ -862,7 +867,7 @@
 		{/if}
 	</div>
 
-	{#if undoMoves.length >= 2}
+	{#if undoMoves.length >= 2 && (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
 		<div class="mt-2 flex justify-center">
 			<span class="text-md rounded-full bg-purple-600 px-3 py-1 font-semibold text-white shadow-md">
 				Hold Green Front, White Up

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -925,7 +925,7 @@
 
 	<div class="my-2 flex w-full flex-col items-center gap-2 md:my-4 md:gap-4">
 		{#if (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'hidden'}
-			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual' && (sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm) !== 'always'}
+			{#if (sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior) === 'manual'}
 				<HintButton
 					alg={displayAlg}
 					visible={true}

--- a/src/lib/components/TrainView/TrainClassicSmart.svelte
+++ b/src/lib/components/TrainView/TrainClassicSmart.svelte
@@ -222,8 +222,11 @@
 
 	function validateMoveProgress() {
 		// Disable algorithm validation and auto-rotation if the hint is hidden or manual
-		const hintAlgorithm = sessionState.activeSession?.settings.trainHintAlgorithm ?? DEFAULT_SETTINGS.trainHintAlgorithm;
-		const hintBehavior = sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
+		const hintAlgorithm =
+			sessionState.activeSession?.settings.trainHintAlgorithm ??
+			DEFAULT_SETTINGS.trainHintAlgorithm;
+		const hintBehavior =
+			sessionState.activeSession?.settings.smartHintBehavior ?? DEFAULT_SETTINGS.smartHintBehavior;
 		if (hintAlgorithm === 'hidden' || hintBehavior === 'manual') {
 			return;
 		}

--- a/src/lib/components/TrainView/TrainView.svelte
+++ b/src/lib/components/TrainView/TrainView.svelte
@@ -11,6 +11,7 @@
 	import TrainClassic from './TrainClassic.svelte';
 	import TrainClassicSmart from './TrainClassicSmart.svelte';
 	import TrainDrill from './TrainDrill.svelte';
+	import TrainClassicScramble from './TrainClassicScramble.svelte';
 	import ResponsiveLayout from './ResponsiveLayout.svelte';
 
 	let showSessionSettings = $state(false);
@@ -68,6 +69,9 @@
 			{#if activeSettings}
 				{#if activeSettings.trainMode === 'drill'}
 					<TrainDrill bind:isRunning={isDrillRunning} />
+				{:else if bluetoothState.isConnected && activeSettings.scrambleYourself}
+					<!-- Scramble Yourself mode (requires classic + connected smart cube) -->
+					<TrainClassicScramble />
 				{:else if bluetoothState.isConnected}
 					<!-- Automatically use smart cube training when connected -->
 					<TrainClassicSmart />

--- a/src/lib/components/TwistyPlayer.svelte
+++ b/src/lib/components/TwistyPlayer.svelte
@@ -133,6 +133,8 @@
 			const [newScramble, newAlg] = concatinateAuf(scrambleWithoutAUF, algWithoutAUF, auf);
 			if (!disableAutoScramble) {
 				scramble = newScramble;
+			} else {
+				scramble = '';
 			}
 			if (showAlg) {
 				alg = simplifyAlg(newAlg);

--- a/src/lib/components/TwistyPlayer.svelte
+++ b/src/lib/components/TwistyPlayer.svelte
@@ -47,7 +47,7 @@
 		showVisibilityToggle?: boolean;
 		tempoScale?: number;
 		showAlg?: boolean;
-		onF2LSolved?: () => void;
+		onF2LSolved?: (entireF2LSolved: boolean) => void;
 		onCubeSolved?: () => void;
 		backView?: 'none' | 'floating';
 		backViewEnabled?: boolean;

--- a/src/lib/components/TwistyPlayer.svelte
+++ b/src/lib/components/TwistyPlayer.svelte
@@ -53,6 +53,7 @@
 		backViewEnabled?: boolean;
 		movesAdded?: string; // Transformed moves for display
 		enableEOColoring?: boolean;
+		disableAutoScramble?: boolean; // if true, scramble from groupid/caseid will not be applied
 	}
 
 	let {
@@ -81,7 +82,8 @@
 		backView = 'none',
 		backViewEnabled = false,
 		movesAdded = $bindable(''),
-		enableEOColoring = false
+		enableEOColoring = false,
+		disableAutoScramble = false
 	}: Props = $props();
 
 	// Raw moves tracked internally for F2L checking (not exposed to parent)
@@ -129,7 +131,9 @@
 	$effect(() => {
 		if (scrambleWithoutAUF !== undefined && algWithoutAUF !== undefined) {
 			const [newScramble, newAlg] = concatinateAuf(scrambleWithoutAUF, algWithoutAUF, auf);
-			scramble = newScramble;
+			if (!disableAutoScramble) {
+				scramble = newScramble;
+			}
 			if (showAlg) {
 				alg = simplifyAlg(newAlg);
 			} else {

--- a/src/lib/components/TwistyPlayer.svelte
+++ b/src/lib/components/TwistyPlayer.svelte
@@ -206,6 +206,10 @@
 	const TWISTY_PLAYER_INIT_DELAY = 100; // Delay in ms to ensure TwistyPlayer is fully initialized
 
 	let stickeringString = $derived.by(() => {
+		if (stickering === 'centers-only') {
+			// 24 hyphens for edges and 24 hyphens for corners to hide all their stickers
+			return 'EDGES:IIIIIIIIIIII,CORNERS:IIIIIIII,CENTERS:------';
+		}
 		if (stickering !== 'f2l' || !staticData) return undefined;
 
 		let baseStr = getStickeringString(staticData.pieceToHide, side, crossColor, frontColor);

--- a/src/lib/globalState.svelte.ts
+++ b/src/lib/globalState.svelte.ts
@@ -32,6 +32,8 @@ interface EphemeralState {
 	isSyncing: boolean;
 	eoOrientedColor: string;
 	eoUnorientedColor: string;
+	showAdvancedTraining: boolean;
+	showAdvancedAppearance: boolean;
 }
 
 const defaultEphemeralState: EphemeralState = {
@@ -49,7 +51,9 @@ const defaultEphemeralState: EphemeralState = {
 	cameraLongitude: DEFAULT_CAMERA_LONGITUDE,
 	isSyncing: false,
 	eoOrientedColor: DEFAULT_EO_ORIENTED_COLOR,
-	eoUnorientedColor: DEFAULT_EO_UNORIENTED_COLOR
+	eoUnorientedColor: DEFAULT_EO_UNORIENTED_COLOR,
+	showAdvancedTraining: false,
+	showAdvancedAppearance: false
 };
 
 const persistedEphemeralState =
@@ -171,5 +175,19 @@ export const globalState: GlobalState = {
 	},
 	set eoUnorientedColor(v) {
 		ephemeralState.eoUnorientedColor = v;
+	},
+
+	get showAdvancedTraining() {
+		return ephemeralState.showAdvancedTraining;
+	},
+	set showAdvancedTraining(v) {
+		ephemeralState.showAdvancedTraining = v;
+	},
+
+	get showAdvancedAppearance() {
+		return ephemeralState.showAdvancedAppearance;
+	},
+	set showAdvancedAppearance(v) {
+		ephemeralState.showAdvancedAppearance = v;
 	}
 };

--- a/src/lib/globalState.svelte.ts
+++ b/src/lib/globalState.svelte.ts
@@ -1,4 +1,4 @@
-import type { GlobalState } from '$lib/types/globalState';
+import type { GlobalState, SessionSettingsTab } from '$lib/types/globalState';
 import { GROUP_DEFINITIONS, GROUP_IDS, type GroupId } from './types/group';
 import { loadFromLocalStorage } from './utils/localStorage';
 
@@ -34,6 +34,7 @@ interface EphemeralState {
 	eoUnorientedColor: string;
 	showAdvancedTraining: boolean;
 	showAdvancedAppearance: boolean;
+	sessionSettingsTab: SessionSettingsTab;
 }
 
 const defaultEphemeralState: EphemeralState = {
@@ -53,7 +54,8 @@ const defaultEphemeralState: EphemeralState = {
 	eoOrientedColor: DEFAULT_EO_ORIENTED_COLOR,
 	eoUnorientedColor: DEFAULT_EO_UNORIENTED_COLOR,
 	showAdvancedTraining: false,
-	showAdvancedAppearance: false
+	showAdvancedAppearance: false,
+	sessionSettingsTab: 'selection'
 };
 
 const persistedEphemeralState =
@@ -189,5 +191,12 @@ export const globalState: GlobalState = {
 	},
 	set showAdvancedAppearance(v) {
 		ephemeralState.showAdvancedAppearance = v;
+	},
+
+	get sessionSettingsTab() {
+		return ephemeralState.sessionSettingsTab;
+	},
+	set sessionSettingsTab(v) {
+		ephemeralState.sessionSettingsTab = v;
 	}
 };

--- a/src/lib/sessionState.svelte.ts
+++ b/src/lib/sessionState.svelte.ts
@@ -28,6 +28,7 @@ export const DEFAULT_SETTINGS: SessionSettings = {
 	trainShowTimer: false,
 	trainHintAlgorithm: 'step',
 	trainHintStickering: 'f2l',
+	smartHintBehavior: 'auto',
 	backView: 'none',
 	backViewEnabled: false,
 	crossColor: ['white'],

--- a/src/lib/sessionState.svelte.ts
+++ b/src/lib/sessionState.svelte.ts
@@ -34,7 +34,10 @@ export const DEFAULT_SETTINGS: SessionSettings = {
 	frontColor: ['red'],
 	trainLearnEO: false,
 	drillTimeBetweenCases: 1.0,
-	drillHideTwistyPlayer: false
+	drillHideTwistyPlayer: false,
+	scrambleYourself: false,
+	scrambleCountdownDuration: 1.0,
+	scrambleShowCube: true
 };
 
 class SessionState {

--- a/src/lib/statisticsState.svelte.ts
+++ b/src/lib/statisticsState.svelte.ts
@@ -58,7 +58,8 @@ const REVERSE_AUF_MAP: Record<CompressedAuf, Auf> = {
 const MODE_MAP: Record<NonNullable<Solve['trainMode']>, NonNullable<CompressedSolve['m']>> = {
 	classic: 'c',
 	smart: 's',
-	drill: 'd'
+	drill: 'd',
+	smartScramble: 'ss'
 };
 
 const REVERSE_MODE_MAP: Record<
@@ -67,7 +68,8 @@ const REVERSE_MODE_MAP: Record<
 > = {
 	c: 'classic',
 	s: 'smart',
-	d: 'drill'
+	d: 'drill',
+	ss: 'smartScramble'
 };
 
 import { sessionState } from '$lib/sessionState.svelte';

--- a/src/lib/trainCases.test.ts
+++ b/src/lib/trainCases.test.ts
@@ -23,8 +23,14 @@ const createMockSettings = (): SessionSettings => ({
 	crossColor: ['white'],
 	frontColor: ['red'],
 
+	trainLearnEO: false,
+
 	drillTimeBetweenCases: 1000,
-	drillHideTwistyPlayer: false
+	drillHideTwistyPlayer: false,
+
+	scrambleYourself: false,
+	scrambleCountdownDuration: 1.0,
+	scrambleShowCube: true
 });
 
 let mockSettings = createMockSettings();

--- a/src/lib/trainCases.test.ts
+++ b/src/lib/trainCases.test.ts
@@ -18,6 +18,7 @@ const createMockSettings = (): SessionSettings => ({
 	trainShowTimer: false,
 	trainHintAlgorithm: 'step',
 	trainHintStickering: 'f2l',
+	smartHintBehavior: 'auto',
 	backView: 'none',
 	backViewEnabled: false,
 	crossColor: ['white'],

--- a/src/lib/types/globalState.ts
+++ b/src/lib/types/globalState.ts
@@ -3,7 +3,7 @@ import type { GroupId } from './group';
 export type View = 'select' | 'train';
 
 export type HintAlgorithm = 'step' | 'allAtOnce' | 'always';
-export type HintStickering = 'f2l' | 'fully';
+export type HintStickering = 'f2l' | 'fully' | 'centers-only';
 
 export interface GlobalState {
 	categoriesOpenedObj: Record<GroupId, boolean[]>;

--- a/src/lib/types/globalState.ts
+++ b/src/lib/types/globalState.ts
@@ -21,4 +21,6 @@ export interface GlobalState {
 	isSyncing: boolean;
 	eoOrientedColor: string;
 	eoUnorientedColor: string;
+	showAdvancedTraining: boolean;
+	showAdvancedAppearance: boolean;
 }

--- a/src/lib/types/globalState.ts
+++ b/src/lib/types/globalState.ts
@@ -2,7 +2,7 @@ import type { GroupId } from './group';
 
 export type View = 'select' | 'train';
 
-export type HintAlgorithm = 'step' | 'allAtOnce' | 'always';
+export type HintAlgorithm = 'step' | 'allAtOnce' | 'always' | 'hidden';
 export type HintStickering = 'f2l' | 'fully' | 'centers-only';
 
 export interface GlobalState {

--- a/src/lib/types/globalState.ts
+++ b/src/lib/types/globalState.ts
@@ -5,6 +5,8 @@ export type View = 'select' | 'train';
 export type HintAlgorithm = 'step' | 'allAtOnce' | 'always' | 'hidden';
 export type HintStickering = 'f2l' | 'fully' | 'centers-only';
 
+export type SessionSettingsTab = 'selection' | 'training' | 'appearance';
+
 export interface GlobalState {
 	categoriesOpenedObj: Record<GroupId, boolean[]>;
 	view: View;
@@ -23,4 +25,5 @@ export interface GlobalState {
 	eoUnorientedColor: string;
 	showAdvancedTraining: boolean;
 	showAdvancedAppearance: boolean;
+	sessionSettingsTab: SessionSettingsTab;
 }

--- a/src/lib/types/session.ts
+++ b/src/lib/types/session.ts
@@ -32,6 +32,7 @@ export interface SessionSettings {
 	// Hints / Visuals
 	trainHintAlgorithm: HintAlgorithm;
 	trainHintStickering: HintStickering;
+	smartHintBehavior: 'auto' | 'manual';
 	backView: 'none' | 'floating';
 	backViewEnabled: boolean; // Controls back-view attribute: true = "top-right", false = "none"
 	crossColor: string[];

--- a/src/lib/types/session.ts
+++ b/src/lib/types/session.ts
@@ -43,6 +43,11 @@ export interface SessionSettings {
 	// Drill Mode
 	drillTimeBetweenCases: number; // Seconds between cases in drill mode
 	drillHideTwistyPlayer: boolean; // Hide TwistyPlayer after first move in drill mode
+
+	// Scramble Yourself Mode
+	scrambleYourself: boolean; // Enable "Scramble Yourself" mode
+	scrambleCountdownDuration: number; // Seconds before solving starts
+	scrambleShowCube: boolean; // Show virtual cube while scrambling
 }
 
 export interface Session {

--- a/src/lib/types/statisticsState.ts
+++ b/src/lib/types/statisticsState.ts
@@ -2,7 +2,7 @@ import type { Auf } from './trainCase';
 import type { Side } from '$lib/types/Side';
 import type { CaseId, GroupId } from './group';
 
-export type TrainMode = 'classic' | 'smart' | 'drill';
+export type TrainMode = 'classic' | 'smart' | 'drill' | 'smartScramble';
 
 export type Solve = {
 	id: string;
@@ -38,7 +38,7 @@ export type CompressedSolve = {
 	// Drill mode timing (optional)
 	rt?: number; // recognitionTime compressed
 	et?: number; // executionTime compressed
-	m: 'c' | 's' | 'd'; // trainMode compressed
+	m: 'c' | 's' | 'd' | 'ss'; // trainMode compressed
 	// Soft delete field
 	da?: number; // deletedAt
 };

--- a/src/lib/utils/checkF2LState.ts
+++ b/src/lib/utils/checkF2LState.ts
@@ -166,13 +166,13 @@ export async function checkF2LState(
 		);
 
 		// Check if the entire F2L is solved (all 4 slots)
-		const entireF2LSolved = piecesToHide 
+		const entireF2LSolved = piecesToHide
 			? isF2LSolved(
 					normalizedPattern.patternData.CORNERS,
 					normalizedPattern.patternData.EDGES,
 					undefined,
 					side
-			  )
+				)
 			: f2lSolved;
 
 		// Check if cube is fully solved

--- a/src/lib/utils/checkF2LState.ts
+++ b/src/lib/utils/checkF2LState.ts
@@ -128,6 +128,7 @@ function isCubeSolved(normalizedPattern: NormalizedPattern): boolean {
 
 export interface F2LState {
 	f2lSolved: boolean;
+	entireF2LSolved: boolean;
 	cubeSolved: boolean;
 }
 
@@ -148,7 +149,7 @@ export async function checkF2LState(
 	alg: string,
 	piecesToHide?: StickerHidden,
 	side: Side = 'right',
-	onF2LSolved?: () => void,
+	onF2LSolved?: (entireF2LSolved: boolean) => void,
 	onCubeSolved?: () => void
 ): Promise<F2LState> {
 	try {
@@ -164,6 +165,16 @@ export async function checkF2LState(
 			side
 		);
 
+		// Check if the entire F2L is solved (all 4 slots)
+		const entireF2LSolved = piecesToHide 
+			? isF2LSolved(
+					normalizedPattern.patternData.CORNERS,
+					normalizedPattern.patternData.EDGES,
+					undefined,
+					side
+			  )
+			: f2lSolved;
+
 		// Check if cube is fully solved
 		const cubeSolved = isCubeSolved(normalizedPattern);
 
@@ -173,7 +184,7 @@ export async function checkF2LState(
 				'%c\u2713 F2L SOLVED!',
 				'color: #fff; background: #27ae60; font-size:1.2rem; font-weight: bold; padding: 4px 12px; border-radius: 4px;'
 			);
-			onF2LSolved?.();
+			onF2LSolved?.(entireF2LSolved);
 		}
 
 		if (cubeSolved) {
@@ -184,9 +195,9 @@ export async function checkF2LState(
 			onCubeSolved?.();
 		}
 
-		return { f2lSolved, cubeSolved };
+		return { f2lSolved, entireF2LSolved, cubeSolved };
 	} catch (e) {
 		console.error('%c[F2L Check Error]', 'color: #e74c3c; font-weight: bold', e);
-		return { f2lSolved: false, cubeSolved: false };
+		return { f2lSolved: false, entireF2LSolved: false, cubeSolved: false };
 	}
 }

--- a/src/lib/utils/moveValidator.test.ts
+++ b/src/lib/utils/moveValidator.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import {
+	isRotationMove,
+	isWideMove,
+	isUMove,
+	wideToSingleLayerMove,
+	getWideImplicitRotation,
+	isSliceMove,
+	getSliceImplicitRotation,
+	getSliceFirstMoves,
+	inverseMove,
+	applyRotationToMove,
+	combineRotations,
+	cancelMoves,
+	normalizeMoves,
+	matchesMoveSequence,
+	inverseRotation,
+	invertRotationsWithoutReversing
+} from './moveValidator';
+
+describe('moveValidator', () => {
+	describe('Move Type Identifiers', () => {
+		it('identifies rotation moves', () => {
+			expect(isRotationMove('x')).toBe(true);
+			expect(isRotationMove("y'")).toBe(true);
+			expect(isRotationMove('z2')).toBe(true);
+			expect(isRotationMove('U')).toBe(false);
+			expect(isRotationMove('r')).toBe(false);
+		});
+
+		it('identifies wide moves', () => {
+			expect(isWideMove('r')).toBe(true);
+			expect(isWideMove("l'")).toBe(true);
+			expect(isWideMove('u2')).toBe(true);
+			expect(isWideMove('R')).toBe(false);
+			expect(isWideMove('M')).toBe(false);
+		});
+
+		it('identifies U-layer moves', () => {
+			expect(isUMove('U')).toBe(true);
+			expect(isUMove("U'")).toBe(true);
+			expect(isUMove('U2')).toBe(true);
+			expect(isUMove('u')).toBe(false);
+			expect(isUMove('R')).toBe(false);
+		});
+
+		it('identifies slice moves', () => {
+			expect(isSliceMove('M')).toBe(true);
+			expect(isSliceMove("E'")).toBe(true);
+			expect(isSliceMove('S2')).toBe(true);
+			expect(isSliceMove('U')).toBe(false);
+			expect(isSliceMove('x')).toBe(false);
+		});
+	});
+
+	describe('Wide and Slice Move Conversions', () => {
+		it('converts wide moves to single layer moves', () => {
+			expect(wideToSingleLayerMove('r')).toBe('L');
+			expect(wideToSingleLayerMove("l'")).toBe("R'");
+			expect(wideToSingleLayerMove('u2')).toBe('D2');
+			expect(wideToSingleLayerMove('R')).toBeNull();
+		});
+
+		it('gets implicit rotations from wide moves', () => {
+			expect(getWideImplicitRotation('r')).toBe('x');
+			expect(getWideImplicitRotation("l'")).toBe('x'); // l is x', l' is x
+			expect(getWideImplicitRotation('u2')).toBe('y2');
+		});
+
+		it('gets implicit rotations from slice moves', () => {
+			expect(getSliceImplicitRotation('M')).toBe("x'");
+			expect(getSliceImplicitRotation("E'")).toBe('y'); // E is y', E' is y
+			expect(getSliceImplicitRotation('S2')).toBe('z2');
+		});
+
+		it('gets first moves for slice moves', () => {
+			expect(getSliceFirstMoves('M')).toEqual(['R', "L'"]);
+			expect(getSliceFirstMoves("E'")).toEqual(["U'", 'D']);
+			expect(getSliceFirstMoves('S2')).toEqual(['F2', 'B2']);
+		});
+	});
+
+	describe('Basic Move Operations', () => {
+		it('inverts single moves', () => {
+			expect(inverseMove('U')).toBe("U'");
+			expect(inverseMove("R'")).toBe('R');
+			expect(inverseMove('F2')).toBe('F2');
+			expect(inverseMove('r')).toBe("r'");
+		});
+	});
+
+	describe('Rotation Operations', () => {
+		it('applies rotation to a move', () => {
+			expect(applyRotationToMove('U', 'x')).toBe('F');
+			expect(applyRotationToMove('F', 'y')).toBe('R');
+			expect(applyRotationToMove('R', "z2 y'")).toBe('B');
+		});
+
+		it('combines rotations', () => {
+			expect(combineRotations(['x', 'x'])).toBe('x2');
+			expect(combineRotations(['y', "y'"])).toBe('');
+			expect(combineRotations(['z2', 'z'])).toBe("z'");
+			expect(combineRotations(['y', 'z'])).toBe('y z');
+		});
+
+		it('inverts rotation sequences', () => {
+			expect(inverseRotation('x')).toBe("x'");
+			expect(inverseRotation("y' z")).toBe("z' y");
+			expect(inverseRotation("z2 y'")).toBe("y z2");
+		});
+
+		it('inverts rotations without reversing order', () => {
+			expect(invertRotationsWithoutReversing('x')).toBe("x'");
+			expect(invertRotationsWithoutReversing("y' z")).toBe("y z'");
+			expect(invertRotationsWithoutReversing("z2 y'")).toBe("z2 y");
+		});
+	});
+
+	describe('Move Sequence Manipulation', () => {
+		it('cancels opposite moves', () => {
+			expect(cancelMoves(['U', "U'"])).toEqual([]);
+			expect(cancelMoves(['R2', 'R2'])).toEqual([]);
+			expect(cancelMoves(['F', 'F'])).toEqual(['F2']);
+			expect(cancelMoves(['L', 'R'])).toEqual(['L', 'R']);
+		});
+
+		it('normalizes move sequences', () => {
+			// Normalize expands slices, coalesces, and cancels
+			// Normalize uses first ordering for slice expansion
+			expect(normalizeMoves(['U', "U'"])).toEqual([]);
+			// M expands to R L' x'
+			// Wait! Does normalizeMoves expand M to [R, L'] or something?
+			// Let's just test basic cancellation for normalizeMoves
+			expect(normalizeMoves(['R', 'R'])).toEqual(['R2']);
+			expect(normalizeMoves(['R', 'L', 'L2'])).toEqual(['R', "L'"]);
+		});
+
+		it('matches equivalent move sequences', () => {
+			const seq1 = ['R', 'U', "R'"];
+			const seq2 = ['R', 'U', "R'"];
+			// Match full sequence
+			expect(matchesMoveSequence(['R', 'U', "R'"], ['R', 'U', "R'"]).match).toBe(true);
+
+			// Match sequence with cancellations (normalizes to ['R', 'U'])
+			expect(matchesMoveSequence(['R', 'U', "F", "F'", "U'", 'U'], ['R', 'U']).match).toBe(true);
+			
+			// Partial matches (matches longer prefix of expected)
+			const performed = ['R', 'U'];
+			const expected = ['R', 'U', "R'"];
+			expect(matchesMoveSequence(performed, expected).match).toBe(true);
+			expect(matchesMoveSequence(performed, expected).consumedCount).toBe(2);
+		});
+	});
+});

--- a/src/lib/utils/moveValidator.test.ts
+++ b/src/lib/utils/moveValidator.test.ts
@@ -106,13 +106,13 @@ describe('moveValidator', () => {
 		it('inverts rotation sequences', () => {
 			expect(inverseRotation('x')).toBe("x'");
 			expect(inverseRotation("y' z")).toBe("z' y");
-			expect(inverseRotation("z2 y'")).toBe("y z2");
+			expect(inverseRotation("z2 y'")).toBe('y z2');
 		});
 
 		it('inverts rotations without reversing order', () => {
 			expect(invertRotationsWithoutReversing('x')).toBe("x'");
 			expect(invertRotationsWithoutReversing("y' z")).toBe("y z'");
-			expect(invertRotationsWithoutReversing("z2 y'")).toBe("z2 y");
+			expect(invertRotationsWithoutReversing("z2 y'")).toBe('z2 y');
 		});
 	});
 
@@ -142,8 +142,8 @@ describe('moveValidator', () => {
 			expect(matchesMoveSequence(['R', 'U', "R'"], ['R', 'U', "R'"]).match).toBe(true);
 
 			// Match sequence with cancellations (normalizes to ['R', 'U'])
-			expect(matchesMoveSequence(['R', 'U', "F", "F'", "U'", 'U'], ['R', 'U']).match).toBe(true);
-			
+			expect(matchesMoveSequence(['R', 'U', 'F', "F'", "U'", 'U'], ['R', 'U']).match).toBe(true);
+
 			// Partial matches (matches longer prefix of expected)
 			const performed = ['R', 'U'];
 			const expected = ['R', 'U', "R'"];

--- a/src/lib/utils/moveValidator.ts
+++ b/src/lib/utils/moveValidator.ts
@@ -637,6 +637,23 @@ function inverseSingleRotation(rotation: string): string {
 }
 
 /**
+ * Get the inverse of each individual rotation in a compound rotation without reversing the order.
+ * This is used for mapping moves from an Old frame to a New frame via applyRotationToMove.
+ * For example: inverse of "y' z" is "y z'"
+ */
+export function invertRotationsWithoutReversing(rotation: string): string {
+	if (!rotation || rotation === '') return '';
+
+	// Handle compound rotations
+	const rotations = rotation.split(' ').filter((r) => r.trim() !== '');
+	if (rotations.length === 0) return '';
+
+	// Invert each rotation without reversing order
+	const inverted = rotations.map((r) => inverseSingleRotation(r));
+	return inverted.join(' ');
+}
+
+/**
  * Get the inverse of a rotation (handles compound rotations like "y' z")
  * For compound rotations, reverses the order and inverts each
  * For example: inverse of "y' z" is "z' y"


### PR DESCRIPTION
# Pull Request: New "Scramble Yourself" Train Mode & UI Improvements

## Description

This PR introduces a brand new training mode—**"Scramble Yourself" Mode (`TrainClassicScramble`)**—where users manually scramble their Bluetooth Smart Cube to match the case, instead of having it pre-scrambled. It also includes substantial UI improvements to the Session Settings Modal, and several bug fixes for hint behavior and undo functionality across all training modes.

## Key Features & Changes

### 🆕 New "Scramble Yourself" Train Mode (`TrainClassicScramble`)
- **Manual Scrambling Integration:** A dedicated new mode where users must physically scramble the cube themselves based on the provided scramble sequence.
- **Improved Scramble UI:**
  - Added directional arrows next to the scramble sequence.
  - Option to hide virtual cube piece colors (showing only center pieces) while scrambling to prevent looking ahead.
  - Removed the green outline when the correct move is applied during scrambling.
  - Added clear instructions on how to hold the cube during this mode.
- **Rotation Matching & Validation:** The smart cube must now be rotated exactly to match the virtual cube's orientation. The app checks if the F2L case is fully solved before automatically proceeding to the next case.
- **Statistics Integration:** The new train mode is fully integrated into the Statistics tracking, Session Stats, and Case Stats Modals.

### ⚙️ Session Settings Modal Enhancements
- **Inline-Editable Session Names:** Session names can now be edited inline directly in the modal header (focus outline and blur issues resolved).
- **Tab Persistence:** The active tab in the session settings modal is now persisted across opens.
- **Advanced Settings:** Reorganized the arrangement, styled advanced buttons, and moved checkboxes for a cleaner interface.

### 💡 Hint & Algorithm Updates
- **"None" Option for Alg Hint:** Users can now select "None" for algorithm hints, which bypasses algorithm validation in `TrainClassicSmart`.
- **"Always Show" Mode Support:** Added a setting to manually show the hint algorithm when the smart cube is connected, properly supporting auto-track vs. manual hint behavior.
- **Visibility Toggles:** Preserved the interactive hint viewer when toggling visibility, and correctly hide hint settings when "Hidden" or "Always Show" is selected.

### 🐛 Bug Fixes & UX Improvements
- **Undo Moves UI:** Changed the "Undo Required" notification to appear on top of the scramble/alg to prevent layout shifts. Undo moves are now cleared when manually selecting the next case.
- **Timer Fixes:** Fixed the timer not resetting when manually switching to the next case.
- **Validation Fixes:** Restored move validation for scrambles in `TrainClassicScramble` and ignored wide move checks when algorithm hints are hidden.